### PR TITLE
add collate options to :string column

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog][keepachangelog], and this project
 adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
+- Added `collate:` opts support to `:string` column type
 
 ## [0.5.1] - 2021-03-18
 - Updated exqlite to 0.5.0

--- a/lib/ecto/adapters/sqlite3.ex
+++ b/lib/ecto/adapters/sqlite3.ex
@@ -91,6 +91,24 @@ defmodule Ecto.Adapters.SQLite3 do
   We have the DSQLITE_LIKE_DOESNT_MATCH_BLOBS compile-time option set to true,
   as [recommended][3] by SQLite. This means you cannot do LIKE queries on BLOB columns.
 
+  ### Case sensitivity
+
+  Case sensitivty for `LIKE` is off by default, and controlled by the `:case_sensitive_like`
+  option outlined above.
+
+  However, for equality comparison, case sensitivity is always _on_.
+  If you want to make a column not be case sensitive, for email storage for example, you can
+  make it case insensitive by using the [`COLLATE NOCASE`][6] option in SQLite. This is configured
+  via the `:collate` option.
+
+  So instead of:
+
+      add :email, :string
+
+  You would do:
+
+      add :email, :string, collate: :nocase
+
   ### Schemaless queries
 
   Using [schemaless Ecto queries][5] will not work well with SQLite. This is because
@@ -101,6 +119,7 @@ defmodule Ecto.Adapters.SQLite3 do
   [3]: https://www.sqlite.org/compile.html
   [4]: https://www.sqlite.org/whentouse.html
   [5]: https://www.sqlite.org/datatype3.html
+  [6]: https://www.sqlite.org/datatype3.html#collating_sequences
   """
 
   use Ecto.Adapters.SQL,

--- a/lib/ecto/adapters/sqlite3/data_type.ex
+++ b/lib/ecto/adapters/sqlite3/data_type.ex
@@ -14,6 +14,18 @@ defmodule Ecto.Adapters.SQLite3.DataType do
   def column_type(:bigint, _opts), do: "INTEGER"
   # TODO: We should make this configurable
   def column_type(:binary_id, _opts), do: "TEXT"
+
+  def column_type(:string, opts) when is_list(opts) do
+    collate = Keyword.get(opts, :collate)
+
+    if collate do
+      str = collate |> Atom.to_string() |> String.upcase()
+      "TEXT COLLATE #{str}"
+    else
+      "TEXT"
+    end
+  end
+
   def column_type(:string, _opts), do: "TEXT"
   def column_type(:float, _opts), do: "NUMERIC"
   def column_type(:binary, _opts), do: "BLOB"

--- a/test/ecto/adapters/sqlite3/data_type_test.exs
+++ b/test/ecto/adapters/sqlite3/data_type_test.exs
@@ -24,6 +24,10 @@ defmodule Ecto.Adapters.SQLite3.DataTypeTest do
       assert DataType.column_type(:string, nil) == "TEXT"
     end
 
+    test ":string, collate: :nocase is TEXT COLLATE NOCASE" do
+      assert DataType.column_type(:string, collate: :nocase) == "TEXT COLLATE NOCASE"
+    end
+
     test ":uuid is TEXT" do
       assert DataType.column_type(:uuid, nil) == "TEXT"
     end

--- a/test/ecto/integration/crud_test.exs
+++ b/test/ecto/integration/crud_test.exs
@@ -191,5 +191,17 @@ defmodule Ecto.Integration.CrudTest do
       assert [] = TestRepo.all from a in Account, where: a.name in ["404"]
       assert [_] = TestRepo.all from a in Account, where: a.name in ["hi"]
     end
+
+    test "handles case sensitive text" do
+      TestRepo.insert!(%Account{name: "hi"})
+      assert [_] = TestRepo.all from a in Account, where: a.name == "hi"
+      assert [] = TestRepo.all from a in Account, where: a.name == "HI"
+    end
+
+    test "handles case insensitive text" do
+      TestRepo.insert!(%Account{name: "hi", email: "hi@hi.com"})
+      assert [_] = TestRepo.all from a in Account, where: a.email == "hi@hi.com"
+      assert [_] = TestRepo.all from a in Account, where: a.email == "HI@HI.COM"
+    end
   end
 end

--- a/test/support/migration.ex
+++ b/test/support/migration.ex
@@ -4,6 +4,7 @@ defmodule EctoSQLite3.Integration.Migration do
   def change do
     create table(:accounts) do
       add(:name, :string)
+      add(:email, :string, collate: :nocase)
       timestamps()
     end
 

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -8,6 +8,7 @@ defmodule EctoSQLite3.Integration.Account do
 
   schema "accounts" do
     field(:name, :string)
+    field(:email, :string)
 
     timestamps()
 


### PR DESCRIPTION
I tried generating a phoenix app with `phx.new` and then added auth with `phx.gen.auth`, and ran the tests and found that one around case-insensitivity failed. This is because Postgres supports case-insensitive with the `citext` extension (which `phx.gen.auth` utilized) and other adpaters are case-insensitive by default, but SQLite is not, so the generated migrations are incorrect for SQLite.

The SQLite solution to this is to have a `COLLATE NOCASE` suffix on the column definition. https://www.sqlite.org/datatype3.html#collating_sequences