### PR TITLE
Update :utc_datetime handling

### DIFF
--- a/lib/ecto/adapters/sqlite3.ex
+++ b/lib/ecto/adapters/sqlite3.ex
@@ -241,22 +241,17 @@ defmodule Ecto.Adapters.SQLite3 do
 
   @impl Ecto.Adapter
   def loaders(:utc_datetime_usec, type) do
-    [&Codec.datetime_decode/1, type]
+    [&Codec.utc_datetime_decode/1, type]
   end
 
   @impl Ecto.Adapter
   def loaders(:utc_datetime, type) do
-    [&Codec.datetime_decode/1, type]
+    [&Codec.utc_datetime_decode/1, type]
   end
 
   @impl Ecto.Adapter
   def loaders(:naive_datetime, type) do
     [&Codec.naive_datetime_decode/1, type]
-  end
-
-  @impl Ecto.Adapter
-  def loaders(:datetime, type) do
-    [&Codec.datetime_decode/1, type]
   end
 
   @impl Ecto.Adapter
@@ -327,7 +322,22 @@ defmodule Ecto.Adapters.SQLite3 do
   end
 
   @impl Ecto.Adapter
+  def dumpers(:utc_datetime, type) do
+    [type, &Codec.utc_datetime_encode/1]
+  end
+
+  @impl Ecto.Adapter
+  def dumpers(:utc_datetime_usec, type) do
+    [type, &Codec.utc_datetime_encode/1]
+  end
+
+  @impl Ecto.Adapter
   def dumpers(:naive_datetime, type) do
+    [type, &Codec.naive_datetime_encode/1]
+  end
+
+  @impl Ecto.Adapter
+  def dumpers(:naive_datetime_usec, type) do
     [type, &Codec.naive_datetime_encode/1]
   end
 

--- a/test/ecto/adapters/sqlite3/codec_test.exs
+++ b/test/ecto/adapters/sqlite3/codec_test.exs
@@ -83,25 +83,21 @@ defmodule Ecto.Adapters.SQLite3.CodecTest do
 
   describe ".utc_datetime_decode/1" do
     test "nil" do
-      {:ok, nil} = Codec.utc_datetime_decode(nil)
+      assert {:ok, nil} = Codec.utc_datetime_decode(nil)
     end
 
     test "string" do
-      {:ok, ~U[2021-08-25 10:58:59Z]} = Codec.utc_datetime_decode("2021-08-25 10:58:59")
+      {:ok, dt} = DateTime.from_naive(~N[2021-08-25 10:58:59Z], "Etc/UTC")
+      assert {:ok, ^dt} = Codec.utc_datetime_decode("2021-08-25 10:58:59")
 
-      {:ok, ~U[2021-08-25 10:58:59.111111Z]} =
-        Codec.utc_datetime_decode("2021-08-25 10:58:59.111111")
-
-      {:ok, ~U[2021-08-25 10:58:59.111111Z]} =
-        Codec.utc_datetime_decode("2021-08-25 10:58:59.111111Z")
+      {:ok, dt} = DateTime.from_naive(~N[2021-08-25 10:58:59.111111], "Etc/UTC")
+      assert {:ok, ^dt} = Codec.utc_datetime_decode("2021-08-25 10:58:59.111111")
     end
 
     test "ignores timezone offset if present" do
-      {:ok, ~U[2021-08-25 10:58:59.111111Z]} =
-        Codec.utc_datetime_decode("2021-08-25 10:58:59.111111Z")
-
-      {:ok, ~U[2021-08-25 10:58:59.111111Z]} =
-        Codec.utc_datetime_decode("2021-08-25 10:58:59.111111+02:30")
+      {:ok, dt} = DateTime.from_naive(~N[2021-08-25 10:58:59.111111], "Etc/UTC")
+      assert {:ok, ^dt} = Codec.utc_datetime_decode("2021-08-25 10:58:59.111111Z")
+      assert {:ok, ^dt} = Codec.utc_datetime_decode("2021-08-25 10:58:59.111111+02:30")
     end
   end
 end

--- a/test/ecto/adapters/sqlite3/codec_test.exs
+++ b/test/ecto/adapters/sqlite3/codec_test.exs
@@ -80,4 +80,28 @@ defmodule Ecto.Adapters.SQLite3.CodecTest do
       {:ok, ^decimal} = Codec.decimal_decode(1.2)
     end
   end
+
+  describe ".utc_datetime_decode/1" do
+    test "nil" do
+      {:ok, nil} = Codec.utc_datetime_decode(nil)
+    end
+
+    test "string" do
+      {:ok, ~U[2021-08-25 10:58:59Z]} = Codec.utc_datetime_decode("2021-08-25 10:58:59")
+
+      {:ok, ~U[2021-08-25 10:58:59.111111Z]} =
+        Codec.utc_datetime_decode("2021-08-25 10:58:59.111111")
+
+      {:ok, ~U[2021-08-25 10:58:59.111111Z]} =
+        Codec.utc_datetime_decode("2021-08-25 10:58:59.111111Z")
+    end
+
+    test "ignores timezone offset if present" do
+      {:ok, ~U[2021-08-25 10:58:59.111111Z]} =
+        Codec.utc_datetime_decode("2021-08-25 10:58:59.111111Z")
+
+      {:ok, ~U[2021-08-25 10:58:59.111111Z]} =
+        Codec.utc_datetime_decode("2021-08-25 10:58:59.111111+02:30")
+    end
+  end
 end


### PR DESCRIPTION
This changes the handling of `:utc_datetime` to not write offsets to the db and ignore them when fetching.

I'm wondering if this one should be changed as well though. 
https://github.com/elixir-sqlite/exqlite/blob/a173dc87e6094a7beb535773b989d596461a3a75/lib/exqlite/sqlite3.ex#L170

It seems neither postgrex nor myxql support `%DateTime{}`s not being supplied in UTC:
Postgrex: 
https://github.com/elixir-ecto/postgrex/blob/60abc91d7d64155e9d5fe587178e063b1083f668/lib/postgrex/extensions/timestamptz.ex#L52-L54
MyXQL: 
https://github.com/elixir-ecto/myxql/blob/fdb147dba07d7699c4af23448996ae7f4663bce6/lib/myxql/protocol/values.ex#L341-L343

The mssql/tds driver seems to have a type for datetimes with offsets.
https://github.com/livehelpnow/tds/blob/36f228275c2bfde2baa45fe70d29d1eb1d44379b/lib/tds/types.ex#L1775-L1788
Usable with custom ecto types it seems: https://github.com/livehelpnow/tds/pull/111#issuecomment-675193597

This PR will currently ignore any offsets, given there's no clear path on how to handle the offset if there is one.

Closes #46 