### PR TITLE
feat: support :time decode

### DIFF
--- a/lib/ecto/adapters/sqlite3.ex
+++ b/lib/ecto/adapters/sqlite3.ex
@@ -240,6 +240,11 @@ defmodule Ecto.Adapters.SQLite3 do
   end
 
   @impl Ecto.Adapter
+  def loaders(:time, type) do
+    [&Codec.time_decode/1, type]
+  end
+
+  @impl Ecto.Adapter
   def loaders(:utc_datetime_usec, type) do
     [&Codec.utc_datetime_decode/1, type]
   end

--- a/lib/ecto/adapters/sqlite3/codec.ex
+++ b/lib/ecto/adapters/sqlite3/codec.ex
@@ -72,6 +72,15 @@ defmodule Ecto.Adapters.SQLite3.Codec do
     end
   end
 
+  def time_decode(nil), do: {:ok, nil}
+
+  def time_decode(value) do
+    case Time.from_iso8601(value) do
+      {:ok, _time} = result -> result
+      {:error, _} -> :error
+    end
+  end
+
   def json_encode(value) do
     Application.get_env(:ecto_sqlite3, :json_library, Jason).encode(value)
   end

--- a/test/ecto/adapters/sqlite3/codec_test.exs
+++ b/test/ecto/adapters/sqlite3/codec_test.exs
@@ -81,6 +81,32 @@ defmodule Ecto.Adapters.SQLite3.CodecTest do
     end
   end
 
+  describe ".time_decode/1" do
+    test "nil" do
+      {:ok, nil} = Codec.time_decode(nil)
+    end
+
+    test "string" do
+      {:ok, time} = Time.from_iso8601("23:50:07")
+      assert {:ok, ^time} = Codec.time_decode("23:50:07")
+
+      {:ok, time} = Time.from_iso8601("23:50:07Z")
+      assert {:ok, ^time} = Codec.time_decode("23:50:07Z")
+
+      {:ok, time} = Time.from_iso8601("T23:50:07Z")
+      assert {:ok, ^time} = Codec.time_decode("T23:50:07Z")
+
+      {:ok, time} = Time.from_iso8601("23:50:07,0123456")
+      assert {:ok, ^time} = Codec.time_decode("23:50:07,0123456")
+
+      {:ok, time} = Time.from_iso8601("23:50:07.0123456")
+      assert {:ok, ^time} = Codec.time_decode("23:50:07.0123456")
+
+      {:ok, time} = Time.from_iso8601("23:50:07.123Z")
+      assert {:ok, ^time} = Codec.time_decode("23:50:07.123Z")
+    end
+  end
+
   describe ".utc_datetime_decode/1" do
     test "nil" do
       assert {:ok, nil} = Codec.utc_datetime_decode(nil)


### PR DESCRIPTION
`ecto_sqlite3` could not decode fields of type `:time`—now it can!

I added tests matching the formats the elixir docs presents in [Time.from_iso8601/2](https://hexdocs.pm/elixir/1.12/Time.html#from_iso8601/2)

edit for posterity: `:time` is listed as a `Ecto.Schema` primitive type https://hexdocs.pm/ecto/Ecto.Schema.html#module-primitive-types