### PR TITLE
Fix/create table options list guard

### DIFF
--- a/lib/ecto/adapters/sqlite3/connection.ex
+++ b/lib/ecto/adapters/sqlite3/connection.ex
@@ -333,7 +333,7 @@ defmodule Ecto.Adapters.SQLite3.Connection do
   ##
 
   @impl true
-  def execute_ddl({_command, %Table{options: keyword}, _}) when keyword != nil do
+  def execute_ddl({_command, %Table{options: options}, _}) when is_list(options) do
     raise ArgumentError, "SQLite3 adapter does not support keyword lists in :options"
   end
 
@@ -1624,7 +1624,7 @@ defmodule Ecto.Adapters.SQLite3.Connection do
 
   defp options_expr(nil), do: []
 
-  defp options_expr(keyword) when is_list(keyword) do
+  defp options_expr(options) when is_list(options) do
     raise ArgumentError, "SQLite3 adapter does not support keyword lists in :options"
   end
 

--- a/test/ecto/adapters/sqlite3/connection_test.exs
+++ b/test/ecto/adapters/sqlite3/connection_test.exs
@@ -2232,12 +2232,12 @@ defmodule Ecto.Adapters.SQLite3.ConnectionTest do
            ]
   end
 
-  test "create table with options" do
+  test "create table with list as options" do
     assert_raise(
       ArgumentError,
       "SQLite3 adapter does not support keyword lists in :options",
       fn ->
-        {:create, table(:posts, options: "WITH FOO=BAR"),
+        {:create, table(:posts, options: ["WITH FOO=BAR"]),
          [{:add, :id, :serial, [primary_key: true]}, {:add, :created_at, :datetime, []}]}
         |> execute_ddl()
       end

--- a/test/ecto/adapters/sqlite3/connection_test.exs
+++ b/test/ecto/adapters/sqlite3/connection_test.exs
@@ -2232,6 +2232,23 @@ defmodule Ecto.Adapters.SQLite3.ConnectionTest do
            ]
   end
 
+  test "create table with options" do
+    create =
+      {:create, table(:posts, options: "WITH FOO=BAR"),
+       [
+         {:add, :id, :serial, [primary_key: true]}
+       ]}
+
+    assert execute_ddl(create) == [
+             """
+             CREATE TABLE "posts" (\
+             "id" INTEGER PRIMARY KEY AUTOINCREMENT\
+             ) \
+             WITH FOO=BAR\
+             """
+           ]
+  end
+
   test "create table with list as options" do
     assert_raise(
       ArgumentError,


### PR DESCRIPTION
When creating a table in a migration with a string passed to the `:options` option, ecto_sqlite3 raises an `ArgumentError` because `execute_ddl` raises on any non-nil value. Considering that the `options_expr` uses an `is_list` guard (as do ecto_sql's Postgres and MySQL adapters), this feels like an error. 