### PR TITLE
Disable logging integration test

### DIFF
--- a/integration_test/test_helper.exs
+++ b/integration_test/test_helper.exs
@@ -112,7 +112,7 @@ ExUnit.start(
     # SQLite3 does not support the concat function
     :concat,
 
-    :placeholders
+    :placeholders,
     
     # Fails the regex matching because it uses square brackets outside of the parameter list
     :parameter_logging

--- a/integration_test/test_helper.exs
+++ b/integration_test/test_helper.exs
@@ -113,5 +113,8 @@ ExUnit.start(
     :concat,
 
     :placeholders
+    
+    # Fails the regex matching because it uses square brackets outside of the parameter list
+    :parameter_logging
   ]
 )


### PR DESCRIPTION
Integration tests were added in ecto_sql to test the logging for casted parameters, but they rely on not using square brackets anywhere else in the log message. It can be disabled this way.