### PR TITLE
Bump Elixir version to 1.11

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule EctoSQLite3.MixProject do
     [
       app: :ecto_sqlite3,
       version: @version,
-      elixir: "~> 1.8",
+      elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       source_url: "https://github.com/elixir-sqlite/ecto_sqlite3",
       homepage_url: "https://github.com/elixir-sqlite/ecto_sqlite3",


### PR DESCRIPTION
Because of https://github.com/elixir-sqlite/ecto_sqlite3/pull/84 this library needs `Calendar.strftime/3` which is only available in Elixir 1.11+