### PR TITLE
Add support for sqlite strict mode.

### DIFF
--- a/lib/ecto/adapters/sqlite3.ex
+++ b/lib/ecto/adapters/sqlite3.ex
@@ -83,8 +83,8 @@ defmodule Ecto.Adapters.SQLite3 do
 
   The `:binary_id_type` configuration option allows configuring how `:binary_id` fields are stored in the database as
   well as the type of the column in which these IDs will be stored. The possible values are:
-  * `:string` (default): IDs are stored as strings, and the type of the column is `TEXT_UUID`.
-  * `:binary`: IDs are stored in their raw binary form, and the type of the column is `UUID`.
+  * `:string` (default): IDs are stored as strings, and the type of the column is `TEXT`.
+  * `:binary`: IDs are stored in their raw binary form, and the type of the column is `BLOB`.
 
   The main differences between the two formats are as follows:
   * When stored as binary, UUIDs require much less space in the database. IDs stored as strings require 36 bytes each,

--- a/lib/ecto/adapters/sqlite3/connection.ex
+++ b/lib/ecto/adapters/sqlite3/connection.ex
@@ -1296,7 +1296,7 @@ defmodule Ecto.Adapters.SQLite3.Connection do
       expr(datetime, sources, query),
       ",",
       interval(count, interval, sources),
-      ") AS TEXT_DATETIME)"
+      ") AS TEXT)"
     ]
   end
 
@@ -1308,7 +1308,7 @@ defmodule Ecto.Adapters.SQLite3.Connection do
       expr(date, sources, query),
       ",",
       interval(count, interval, sources),
-      ") AS TEXT_DATE)"
+      ") AS TEXT)"
     ]
   end
 

--- a/lib/ecto/adapters/sqlite3/data_type.ex
+++ b/lib/ecto/adapters/sqlite3/data_type.ex
@@ -11,6 +11,7 @@ defmodule Ecto.Adapters.SQLite3.DataType do
   def column_type(:id, _opts), do: "INTEGER"
   def column_type(:serial, _opts), do: "INTEGER"
   def column_type(:bigserial, _opts), do: "INTEGER"
+  def column_type(:boolean, _opts), do: "INTEGER"
   def column_type(:bigint, _opts), do: "INTEGER"
   def column_type(:string, _opts), do: "TEXT"
   def column_type(:float, _opts), do: "NUMERIC"
@@ -19,10 +20,10 @@ defmodule Ecto.Adapters.SQLite3.DataType do
   def column_type(:array, _opts), do: "JSON"
   def column_type({:map, _}, _opts), do: "JSON"
   def column_type({:array, _}, _opts), do: "JSON"
-  def column_type(:utc_datetime, _opts), do: "TEXT_DATETIME"
-  def column_type(:utc_datetime_usec, _opts), do: "TEXT_DATETIME"
-  def column_type(:naive_datetime, _opts), do: "TEXT_DATETIME"
-  def column_type(:naive_datetime_usec, _opts), do: "TEXT_DATETIME"
+  def column_type(:utc_datetime, _opts), do: "TEXT"
+  def column_type(:utc_datetime_usec, _opts), do: "TEXT"
+  def column_type(:naive_datetime, _opts), do: "TEXT"
+  def column_type(:naive_datetime_usec, _opts), do: "TEXT"
   def column_type(:decimal, nil), do: "DECIMAL"
 
   def column_type(:decimal, opts) do
@@ -39,15 +40,15 @@ defmodule Ecto.Adapters.SQLite3.DataType do
 
   def column_type(:binary_id, _opts) do
     case Application.get_env(:ecto_sqlite3, :binary_id_type, :string) do
-      :string -> "TEXT_UUID"
-      :binary -> "UUID"
+      :string -> "TEXT"
+      :binary -> "BLOB"
     end
   end
 
   def column_type(:uuid, _opts) do
     case Application.get_env(:ecto_sqlite3, :uuid_type, :string) do
-      :string -> "TEXT_UUID"
-      :binary -> "UUID"
+      :string -> "TEXT"
+      :binary -> "BLOB"
     end
   end
 

--- a/test/ecto/adapters/sqlite3/connection_test.exs
+++ b/test/ecto/adapters/sqlite3/connection_test.exs
@@ -955,7 +955,7 @@ defmodule Ecto.Adapters.SQLite3.ConnectionTest do
       |> select([], type(^"601d74e4-a8d3-4b6e-8365-eddb4c893327", Ecto.UUID))
       |> plan()
 
-    assert all(query) == ~s{SELECT CAST(? AS TEXT_UUID) FROM "schema" AS s0}
+    assert all(query) == ~s{SELECT CAST(? AS TEXT) FROM "schema" AS s0}
   end
 
   test "string type" do
@@ -2152,7 +2152,7 @@ defmodule Ecto.Adapters.SQLite3.ConnectionTest do
           [precision: 8, scale: 2, default: {:fragment, "expr"}]},
          {:add, :on_hand, :integer, [default: 0, null: true]},
          {:add, :likes, :integer, [default: 0, null: false]},
-         {:add, :published_at, :datetime, [null: true]},
+         {:add, :published_at, :utc_datetime, [null: true]},
          {:add, :is_active, :boolean, [default: true]},
          {:add, :notes, :text, [collate: :nocase]},
          {:add, :meta, :text, [check: %{name: "meta_constraint", expr: "meta != 'a'"}]}
@@ -2166,8 +2166,8 @@ defmodule Ecto.Adapters.SQLite3.ConnectionTest do
              "price" NUMERIC DEFAULT expr, \
              "on_hand" INTEGER DEFAULT 0 NULL, \
              "likes" INTEGER DEFAULT 0 NOT NULL, \
-             "published_at" DATETIME NULL, \
-             "is_active" BOOLEAN DEFAULT true, \
+             "published_at" TEXT NULL, \
+             "is_active" INTEGER DEFAULT true, \
              "notes" TEXT COLLATE NOCASE, \
              "meta" TEXT CONSTRAINT meta_constraint CHECK (meta != 'a')\
              )\
@@ -2337,8 +2337,8 @@ defmodule Ecto.Adapters.SQLite3.ConnectionTest do
     assert execute_ddl(create) == [
              """
              CREATE TABLE "posts" (\
-             "published_at" TEXT_DATETIME, \
-             "submitted_at" TEXT_DATETIME\
+             "published_at" TEXT, \
+             "submitted_at" TEXT\
              )\
              """
            ]
@@ -2353,7 +2353,7 @@ defmodule Ecto.Adapters.SQLite3.ConnectionTest do
        ]}
 
     assert execute_ddl(create) == [
-             ~s{CREATE TABLE "posts" ("published_at" TEXT_DATETIME, "submitted_at" TEXT_DATETIME)}
+             ~s{CREATE TABLE "posts" ("published_at" TEXT, "submitted_at" TEXT)}
            ]
   end
 
@@ -2443,7 +2443,7 @@ defmodule Ecto.Adapters.SQLite3.ConnectionTest do
              """,
              """
              ALTER TABLE "posts" \
-             ADD COLUMN "when" TEXT_DATETIME\
+             ADD COLUMN "when" TEXT\
              """
            ]
   end

--- a/test/ecto/adapters/sqlite3/data_type_test.exs
+++ b/test/ecto/adapters/sqlite3/data_type_test.exs
@@ -26,24 +26,24 @@ defmodule Ecto.Adapters.SQLite3.DataTypeTest do
       assert DataType.column_type(:bigserial, nil) == "INTEGER"
     end
 
-    test ":binary_id is TEXT_UUID OR UUID" do
-      assert DataType.column_type(:binary_id, nil) == "TEXT_UUID"
+    test ":binary_id is TEXT OR UUID" do
+      assert DataType.column_type(:binary_id, nil) == "TEXT"
 
       Application.put_env(:ecto_sqlite3, :binary_id_type, :binary)
 
-      assert DataType.column_type(:binary_id, nil) == "UUID"
+      assert DataType.column_type(:binary_id, nil) == "BLOB"
     end
 
     test ":string is TEXT" do
       assert DataType.column_type(:string, nil) == "TEXT"
     end
 
-    test ":uuid is TEXT_UUID or UUID" do
-      assert DataType.column_type(:uuid, nil) == "TEXT_UUID"
+    test ":uuid is TEXT or UUID" do
+      assert DataType.column_type(:uuid, nil) == "TEXT"
 
       Application.put_env(:ecto_sqlite3, :uuid_type, :binary)
 
-      assert DataType.column_type(:uuid, nil) == "UUID"
+      assert DataType.column_type(:uuid, nil) == "BLOB"
     end
 
     test ":map is JSON" do
@@ -82,20 +82,20 @@ defmodule Ecto.Adapters.SQLite3.DataTypeTest do
       assert DataType.column_type(:binary, nil) == "BLOB"
     end
 
-    test ":utc_datetime is DATETIME" do
-      assert DataType.column_type(:utc_datetime, nil) == "TEXT_DATETIME"
+    test ":utc_datetime is TEXT" do
+      assert DataType.column_type(:utc_datetime, nil) == "TEXT"
     end
 
-    test ":utc_datetime_usec is DATETIME" do
-      assert DataType.column_type(:utc_datetime_usec, nil) == "TEXT_DATETIME"
+    test ":utc_datetime_usec is TEXT" do
+      assert DataType.column_type(:utc_datetime_usec, nil) == "TEXT"
     end
 
-    test ":naive_datetime is DATETIME" do
-      assert DataType.column_type(:naive_datetime, nil) == "TEXT_DATETIME"
+    test ":naive_datetime is TEXT" do
+      assert DataType.column_type(:naive_datetime, nil) == "TEXT"
     end
 
-    test ":naive_datetime_usec is DATETIME" do
-      assert DataType.column_type(:naive_datetime_usec, nil) == "TEXT_DATETIME"
+    test ":naive_datetime_usec is TEXT" do
+      assert DataType.column_type(:naive_datetime_usec, nil) == "TEXT"
     end
   end
 end


### PR DESCRIPTION
For review. I am not sure how to enable strict mode. I added the lines `options: "STRICT"` to force strict mode.

This fixes problems with uuids, booleans and datetimes on strict mode. We must use the correct sql types.

Help on how to run the test suite.

```elixir
defmodule Uro.Repo.Migrations.CreateUsers do
  use Ecto.Migration

  def change do
    create table(:users, primary_key: false, options: "STRICT, WITHOUT ROWID") do
      add :id, :uuid, primary_key: true
      add :email, :string, null: false
      add :password_hash, :string

      add :username, :string
      add :display_name, :string

      add :email_notifications, :boolean, default: false

      add :profile_picture, :string
      add :is_admin, :boolean

      timestamps()
    end

    create unique_index(:users, :username)
    create unique_index(:users, :email)
  end
end
```

https://www.sqlite.org/draft/stricttables.html