### PR TITLE
Enable AUTOINCREMENT for serial and bigserial

### DIFF
--- a/lib/ecto/adapters/sqlite3/connection.ex
+++ b/lib/ecto/adapters/sqlite3/connection.ex
@@ -1581,20 +1581,12 @@ defmodule Ecto.Adapters.SQLite3.Connection do
     collate = Keyword.get(opts, :collate)
     check = Keyword.get(opts, :check)
 
-    column_options(default, type, null, pk, collate, check)
-  end
-
-  defp column_options(_default, :serial, _, true, _, _) do
-    " PRIMARY KEY AUTOINCREMENT"
-  end
-
-  defp column_options(default, type, null, pk, collate, check) do
     [
       default_expr(default, type),
       null_expr(null),
       collate_expr(collate),
       check_expr(check),
-      pk_expr(pk)
+      pk_expr(pk, type)
     ]
   end
 
@@ -1660,8 +1652,11 @@ defmodule Ecto.Adapters.SQLite3.Connection do
   defp index_expr(literal) when is_binary(literal), do: literal
   defp index_expr(literal), do: quote_name(literal)
 
-  defp pk_expr(true), do: " PRIMARY KEY"
-  defp pk_expr(_), do: []
+  defp pk_expr(true, type) when type in [:serial, :bigserial],
+    do: " PRIMARY KEY AUTOINCREMENT"
+
+  defp pk_expr(true, _), do: " PRIMARY KEY"
+  defp pk_expr(_, _), do: []
 
   defp options_expr(nil), do: []
 

--- a/test/ecto/adapters/sqlite3/connection_test.exs
+++ b/test/ecto/adapters/sqlite3/connection_test.exs
@@ -2787,4 +2787,20 @@ defmodule Ecto.Adapters.SQLite3.ConnectionTest do
 
     assert query == ~s{SELECT p0."id", p0."title", p0."content" FROM "posts" AS p0}
   end
+
+  test "autoincrement support" do
+    serial = {:create, table(:posts), [{:add, :id, :bigserial, [primary_key: true]}]}
+    bigserial = {:create, table(:posts), [{:add, :id, :bigserial, [primary_key: true]}]}
+    id = {:create, table(:posts), [{:add, :id, :id, [primary_key: true]}]}
+
+    assert execute_ddl(serial) == [
+             ~s/CREATE TABLE "posts" ("id" INTEGER PRIMARY KEY AUTOINCREMENT)/
+           ]
+
+    assert execute_ddl(bigserial) == [
+             ~s/CREATE TABLE "posts" ("id" INTEGER PRIMARY KEY AUTOINCREMENT)/
+           ]
+
+    assert execute_ddl(id) == [~s/CREATE TABLE "posts" ("id" INTEGER PRIMARY KEY)/]
+  end
 end

--- a/test/ecto/adapters/sqlite3/connection_test.exs
+++ b/test/ecto/adapters/sqlite3/connection_test.exs
@@ -2789,9 +2789,10 @@ defmodule Ecto.Adapters.SQLite3.ConnectionTest do
   end
 
   test "autoincrement support" do
-    serial = {:create, table(:posts), [{:add, :id, :bigserial, [primary_key: true]}]}
+    serial = {:create, table(:posts), [{:add, :id, :serial, [primary_key: true]}]}
     bigserial = {:create, table(:posts), [{:add, :id, :bigserial, [primary_key: true]}]}
     id = {:create, table(:posts), [{:add, :id, :id, [primary_key: true]}]}
+    integer = {:create, table(:posts), [{:add, :id, :integer, [primary_key: true]}]}
 
     assert execute_ddl(serial) == [
              ~s/CREATE TABLE "posts" ("id" INTEGER PRIMARY KEY AUTOINCREMENT)/
@@ -2802,5 +2803,6 @@ defmodule Ecto.Adapters.SQLite3.ConnectionTest do
            ]
 
     assert execute_ddl(id) == [~s/CREATE TABLE "posts" ("id" INTEGER PRIMARY KEY)/]
+    assert execute_ddl(integer) == [~s/CREATE TABLE "posts" ("id" INTEGER PRIMARY KEY)/]
   end
 end


### PR DESCRIPTION
#94 Enables AUTOINCREMENT for primary keys of type `:bigserial`.  Note that `:serial` was already set as AUTOINCREMENT.
