### PR TITLE
Missing literal, selected_as and using CAST for floats.

### DIFF
--- a/lib/ecto/adapters/sqlite3/connection.ex
+++ b/lib/ecto/adapters/sqlite3/connection.ex
@@ -1373,7 +1373,7 @@ defmodule Ecto.Adapters.SQLite3.Connection do
     end
   end
 
-  #TODO It technically is, its just a json array, so we *could* support it
+  # TODO It technically is, its just a json array, so we *could* support it
   def expr(list, _sources, query) when is_list(list) do
     raise Ecto.QueryError,
       query: query,

--- a/test/ecto/adapters/sqlite3/connection_test.exs
+++ b/test/ecto/adapters/sqlite3/connection_test.exs
@@ -946,7 +946,28 @@ defmodule Ecto.Adapters.SQLite3.ConnectionTest do
       |> select([], true)
       |> plan()
 
-    assert all(query) == ~s{SELECT 1 FROM "schema" AS s0 WHERE (s0."foo" = (0 + 123.0))}
+    assert all(query) == ~s{SELECT 1 FROM "schema" AS s0 WHERE (s0."foo" = CAST(123.0 AS REAL))}
+
+    name = "y"
+    query =
+      "schema"
+      |> where(fragment("? = ?", literal(^name), "Main"))
+      |> select([], true)
+      |> plan()
+
+    assert all(query) == ~s|SELECT 1 FROM "schema" AS s0 WHERE ("y" = 'Main')|
+  end
+
+  test "selected_as" do
+    query = 
+        from(s in "schema", 
+          select: %{
+            y: selected_as(s.y, :y2),
+          }
+        )
+        |> plan()
+
+    assert all(query) == ~s|SELECT s0."y" AS "y2" FROM "schema" AS s0|
   end
 
   test "tagged type" do

--- a/test/ecto/adapters/sqlite3/connection_test.exs
+++ b/test/ecto/adapters/sqlite3/connection_test.exs
@@ -946,9 +946,11 @@ defmodule Ecto.Adapters.SQLite3.ConnectionTest do
       |> select([], true)
       |> plan()
 
-    assert all(query) == ~s{SELECT 1 FROM "schema" AS s0 WHERE (s0."foo" = CAST(123.0 AS REAL))}
+    assert all(query) ==
+             ~s{SELECT 1 FROM "schema" AS s0 WHERE (s0."foo" = CAST(123.0 AS REAL))}
 
     name = "y"
+
     query =
       "schema"
       |> where(fragment("? = ?", literal(^name), "Main"))
@@ -959,13 +961,13 @@ defmodule Ecto.Adapters.SQLite3.ConnectionTest do
   end
 
   test "selected_as" do
-    query = 
-        from(s in "schema", 
-          select: %{
-            y: selected_as(s.y, :y2),
-          }
-        )
-        |> plan()
+    query =
+      from(s in "schema",
+        select: %{
+          y: selected_as(s.y, :y2)
+        }
+      )
+      |> plan()
 
     assert all(query) == ~s|SELECT s0."y" AS "y2" FROM "schema" AS s0|
   end

--- a/test/ecto/integration/crud_test.exs
+++ b/test/ecto/integration/crud_test.exs
@@ -245,12 +245,11 @@ defmodule Ecto.Integration.CrudTest do
       assert [_] = TestRepo.all(from(a in Account, as: :user, where: exists(subquery)))
     end
 
-    test "can handle fragment literal" do 
+    test "can handle fragment literal" do
       account1 = TestRepo.insert!(%Account{name: "Main"})
 
       name = "name"
-      query =
-        from(a in Account, where: fragment("? = ?", literal(^name), "Main"))
+      query = from(a in Account, where: fragment("? = ?", literal(^name), "Main"))
 
       assert [account] = TestRepo.all(query)
       assert account.id == account1.id
@@ -263,7 +262,7 @@ defmodule Ecto.Integration.CrudTest do
       TestRepo.insert!(%Account{name: "Main3"})
 
       query =
-        from(a in Account, 
+        from(a in Account,
           select: %{
             name: selected_as(a.name, :name2),
             count: count()
@@ -271,7 +270,11 @@ defmodule Ecto.Integration.CrudTest do
           group_by: selected_as(:name2)
         )
 
-      assert [%{name: "Main", count: 2}, %{name: "Main2", count: 1}, %{name: "Main3", count: 1}] = TestRepo.all(query)
+      assert [
+               %{name: "Main", count: 2},
+               %{name: "Main2", count: 1},
+               %{name: "Main3", count: 1}
+             ] = TestRepo.all(query)
     end
 
     test "can handle floats" do
@@ -281,7 +284,7 @@ defmodule Ecto.Integration.CrudTest do
       two = 2.0
 
       query =
-        from(a in Account, 
+        from(a in Account,
           select: %{
             sum: ^one + ^two
           }


### PR DESCRIPTION
I was playing around some queries and noticed [literals](https://hexdocs.pm/ecto/Ecto.Query.API.html#fragment/1-literals) and [selected_as](https://hexdocs.pm/ecto/Ecto.Query.API.html#selected_as/2) was not implemented.

I also saw the comment about being unsure about floats so I just read the guide and it has CAST as <x> if we know the type. I chose REAL but it looks like FLOAT would also work LMK if you think I should change it.

