### PR TITLE
Fix bad init file loading in dump_cmd/3

### DIFF
--- a/lib/ecto/adapters/sqlite3.ex
+++ b/lib/ecto/adapters/sqlite3.ex
@@ -266,7 +266,7 @@ defmodule Ecto.Adapters.SQLite3 do
 
   @impl Ecto.Adapter.Structure
   def dump_cmd(args, opts \\ [], config) when is_list(config) and is_list(args) do
-    run_with_cmd("sqlite3", [config[:database] | args], opts)
+    run_with_cmd("sqlite3", ["-init", "/dev/null", config[:database] | args], opts)
   end
 
   @impl Ecto.Adapter.Schema


### PR DESCRIPTION
A test over dump_cmd/3 was failing with a strange error:

```
$ mix test
Compiling 2 files (.ex)
.........................warning: missing `:on` in join, defaulting to `on: true`.
  test/ecto/adapters/sqlite3/connection_test.exs:307: Ecto.Adapters.SQLite3.ConnectionTest."test parent binding subquery and CTE"/1

warning: missing `:on` in join on Ecto.Adapters.SQLite3.ConnectionTest.Schema2, defaulting to `on: true`.
  test/ecto/adapters/sqlite3/connection_test.exs:1412: Ecto.Adapters.SQLite3.ConnectionTest."test join with hints"/1

warning: missing `:on` in join, defaulting to `on: true`.
  test/ecto/adapters/sqlite3/connection_test.exs:1478: Ecto.Adapters.SQLite3.ConnectionTest."test join with subquery"/1

warning: missing `:on` in join, defaulting to `on: true`.
  test/ecto/adapters/sqlite3/connection_test.exs:1515: Ecto.Adapters.SQLite3.ConnectionTest."test join with fragment"/1

warning: missing `:on` in join, defaulting to `on: true`.
  test/ecto/adapters/sqlite3/connection_test.exs:1548: Ecto.Adapters.SQLite3.ConnectionTest."test join with query interpolation"/1

warning: missing `:on` in join, defaulting to `on: true`.
  test/ecto/adapters/sqlite3/connection_test.exs:1557: Ecto.Adapters.SQLite3.ConnectionTest."test lateral join with fragment"/1

...................................................................................................................................................................................

  1) test dump_cmd/3 runs command (Ecto.Adapters.SQLite3ConnTest)
     test/ecto/adapters/sqlite3_test.exs:86
     match (=) failed
     code:  assert {"CREATE TABLE test (id INTEGER PRIMARY KEY);\n", 0} = SQLite3.dump_cmd([".schema"], [], opts)
     left:  {"CREATE TABLE test (id INTEGER PRIMARY KEY);\n", 0}
     right: {".auth off\n.mode column\n.headers on\n.prompt \"> \"\nCREATE TABLE test (id INTEGER PRIMARY KEY);\n", 0}
     stacktrace:
       test/ecto/adapters/sqlite3_test.exs:98: (test)

.........................
Finished in 0.8 seconds (0.7s async, 0.09s sync)
230 tests, 1 failure

Randomized with seed 760049
```

The reason? Well, it's probably my [`.sqliterc`](https://github.com/joeljuca/cli/blob/main/config/sqlite/sqliterc):

```
.echo on
.auth off
.mode column
.headers on
.prompt "> "
```

The `sqlite3` program loads an initialization file `~/.sqliterc`, if present. Since I do have one, it'll be used during `dump_cmd/3` operations. It's quite a dangerous behavior since any destructive command present in `~/.sqliterc` will be executed against a project's database, possibly destroying data, etc.

I couldn't find a way to make `sqlite3` not load my `.sqliterc`, but after setting `/dev/null` as `-init` argument, test passes again (and my `.sqliterc` is not being loaded/used).