### PR TITLE
Add missing :date column type

### DIFF
--- a/lib/ecto/adapters/sqlite3/codec.ex
+++ b/lib/ecto/adapters/sqlite3/codec.ex
@@ -70,7 +70,7 @@ defmodule Ecto.Adapters.SQLite3.Codec do
 
   def date_encode(val), do: date_encode(val, :iso8601)
 
-  def date_encode(val, :iso8601) do
+  def date_encode(%Date{} = val, :iso8601) do
     case Date.to_iso8601(val) do
       date when is_bitstring(date) -> {:ok, date}
       _ -> :error

--- a/lib/ecto/adapters/sqlite3/codec.ex
+++ b/lib/ecto/adapters/sqlite3/codec.ex
@@ -68,6 +68,15 @@ defmodule Ecto.Adapters.SQLite3.Codec do
     end
   end
 
+  def date_encode(val), do: date_encode(val, :iso8601)
+
+  def date_encode(val, :iso8601) do
+    case Date.to_iso8601(val) do
+      date when is_bitstring(date) -> {:ok, date}
+      _ -> :error
+    end
+  end
+
   def time_decode(nil), do: {:ok, nil}
 
   def time_decode(value) do

--- a/lib/ecto/adapters/sqlite3/data_type.ex
+++ b/lib/ecto/adapters/sqlite3/data_type.ex
@@ -20,6 +20,7 @@ defmodule Ecto.Adapters.SQLite3.DataType do
   def column_type(:array, _opts), do: "TEXT"
   def column_type({:map, _}, _opts), do: "TEXT"
   def column_type({:array, _}, _opts), do: "TEXT"
+  def column_type(:date, _opts), do: "TEXT"
   def column_type(:utc_datetime, _opts), do: "TEXT"
   def column_type(:utc_datetime_usec, _opts), do: "TEXT"
   def column_type(:naive_datetime, _opts), do: "TEXT"

--- a/test/ecto/adapters/sqlite3/codec_test.exs
+++ b/test/ecto/adapters/sqlite3/codec_test.exs
@@ -176,4 +176,21 @@ defmodule Ecto.Adapters.SQLite3.CodecTest do
       end
     end
   end
+
+  describe ".date_encode/2" do
+    setup do
+      [
+        date: ~D[2011-01-09],
+        datetime: ~U[2011-01-09 08:46:08.00Z]
+      ]
+    end
+
+    test "on %Date{} structs", %{date: date} do
+      {:ok, "2011-01-09"} = Codec.date_encode(date, :iso8601)
+    end
+
+    test "on %DateTime{} structs", %{datetime: datetime} do
+      {:ok, "2011-01-09"} = Codec.date_encode(datetime, :iso8601)
+    end
+  end
 end

--- a/test/ecto/adapters/sqlite3/codec_test.exs
+++ b/test/ecto/adapters/sqlite3/codec_test.exs
@@ -188,9 +188,5 @@ defmodule Ecto.Adapters.SQLite3.CodecTest do
     test "on %Date{} structs", %{date: date} do
       {:ok, "2011-01-09"} = Codec.date_encode(date, :iso8601)
     end
-
-    test "on %DateTime{} structs", %{datetime: datetime} do
-      {:ok, "2011-01-09"} = Codec.date_encode(datetime, :iso8601)
-    end
   end
 end


### PR DESCRIPTION
I'm still new to Ecto adapters so I'm not 100% confident this is the right way to do it, but I noticed that `:date` fields are not correctly mapped to the equivalent SQLite data type, so here's a PR trying to fix it.