### PR TITLE
Support other unique constraint error format

### DIFF
--- a/lib/ecto/adapters/sqlite3/connection.ex
+++ b/lib/ecto/adapters/sqlite3/connection.ex
@@ -131,6 +131,13 @@ defmodule Ecto.Adapters.SQLite3.Connection do
 
   @impl true
   def to_constraints(
+        %Exqlite.Error{message: "UNIQUE constraint failed: index " <> constraint},
+        _opts
+      ) do
+    [unique: String.trim(constraint, ~s('))]
+  end
+
+  def to_constraints(
         %Exqlite.Error{message: "UNIQUE constraint failed: " <> constraint},
         _opts
       ) do

--- a/test/ecto/adapters/sqlite3/connection_test.exs
+++ b/test/ecto/adapters/sqlite3/connection_test.exs
@@ -2428,7 +2428,10 @@ defmodule Ecto.Adapters.SQLite3.ConnectionTest do
     end
 
     test "complex unique index" do
-      error = %Exqlite.Error{message: "UNIQUE constraint failed: index 'one_two_three_index'"}
+      error = %Exqlite.Error{
+        message: "UNIQUE constraint failed: index 'one_two_three_index'"
+      }
+
       assert Connection.to_constraints(error, []) == [unique: "one_two_three_index"]
     end
   end

--- a/test/ecto/adapters/sqlite3/connection_test.exs
+++ b/test/ecto/adapters/sqlite3/connection_test.exs
@@ -2417,22 +2417,34 @@ defmodule Ecto.Adapters.SQLite3.ConnectionTest do
   describe "to_constraints/2" do
     alias Ecto.Adapters.SQLite3.Connection
 
-    test "simple unique index" do
-      error = %Exqlite.Error{message: "UNIQUE constraint failed: one.two.three"}
-      assert Connection.to_constraints(error, []) == [unique: "one_two_three_index"]
+    test "unique index" do
+      # created with:
+      # CREATE UNIQUE INDEX users_email_name_index ON users (email);
+
+      error = %Exqlite.Error{message: "UNIQUE constraint failed: users.email"}
+      assert Connection.to_constraints(error, []) == [unique: "users_email_index"]
     end
 
     test "multi-column unique index" do
-      error = %Exqlite.Error{message: "UNIQUE constraint failed: one.two, one.three"}
-      assert Connection.to_constraints(error, []) == [unique: "one_two_three_index"]
+      # created with:
+      # CREATE UNIQUE INDEX users_email_name_index ON users (email, name);
+
+      error = %Exqlite.Error{
+        message: "UNIQUE constraint failed: users.email, users.name"
+      }
+
+      assert Connection.to_constraints(error, []) == [unique: "users_email_name_index"]
     end
 
     test "complex unique index" do
+      # created with:
+      # CREATE UNIQUE INDEX users_email_year_index ON users (email, strftime('%Y', inserted_at));
+
       error = %Exqlite.Error{
-        message: "UNIQUE constraint failed: index 'one_two_three_index'"
+        message: "UNIQUE constraint failed: index 'users_email_year_index'"
       }
 
-      assert Connection.to_constraints(error, []) == [unique: "one_two_three_index"]
+      assert Connection.to_constraints(error, []) == [unique: "users_email_year_index"]
     end
   end
 

--- a/test/ecto/adapters/sqlite3/connection_test.exs
+++ b/test/ecto/adapters/sqlite3/connection_test.exs
@@ -2414,6 +2414,20 @@ defmodule Ecto.Adapters.SQLite3.ConnectionTest do
     assert execute_ddl(integer) == [~s/CREATE TABLE "posts" ("id" INTEGER PRIMARY KEY)/]
   end
 
+  describe "to_constraints/2" do
+    alias Ecto.Adapters.SQLite3.Connection
+
+    test "simple unique index" do
+      error = %Exqlite.Error{message: "UNIQUE constraint failed: one.two.three"}
+      assert Connection.to_constraints(error, []) == [unique: "one_two_three_index"]
+    end
+
+    test "complex unique index" do
+      error = %Exqlite.Error{message: "UNIQUE constraint failed: index 'one_two_three_index'"}
+      assert Connection.to_constraints(error, []) == [unique: "one_two_three_index"]
+    end
+  end
+
   defp remove_newlines(string) do
     string |> String.trim() |> String.replace("\n", " ")
   end

--- a/test/ecto/adapters/sqlite3/connection_test.exs
+++ b/test/ecto/adapters/sqlite3/connection_test.exs
@@ -2422,6 +2422,11 @@ defmodule Ecto.Adapters.SQLite3.ConnectionTest do
       assert Connection.to_constraints(error, []) == [unique: "one_two_three_index"]
     end
 
+    test "multi-column unique index" do
+      error = %Exqlite.Error{message: "UNIQUE constraint failed: one.two, one.three"}
+      assert Connection.to_constraints(error, []) == [unique: "one_two_three_index"]
+    end
+
     test "complex unique index" do
       error = %Exqlite.Error{message: "UNIQUE constraint failed: index 'one_two_three_index'"}
       assert Connection.to_constraints(error, []) == [unique: "one_two_three_index"]


### PR DESCRIPTION
Unique constraints sometimes fail with the following error format:
`UNIQUE constraint failed: index '<index_name>'`

I believe this happens when the index name doesn't match the names of the columns involved.

Example of an index for which this happens:

```sql
CREATE UNIQUE INDEX table_user_id_number_year_index ON table (user_id, number, strftime('%Y', created_at));
```

Resolves https://github.com/elixir-sqlite/ecto_sqlite3/issues/89