### PR TITLE
Fix binary uuid casting

### DIFF
--- a/lib/ecto/adapters/sqlite3/connection.ex
+++ b/lib/ecto/adapters/sqlite3/connection.ex
@@ -1431,6 +1431,17 @@ defmodule Ecto.Adapters.SQLite3.Connection do
     [?x, ?', hex, ?']
   end
 
+  def expr(%Ecto.Query.Tagged{value: {:^, _, [_]} = expr, type: type}, sources, query)
+      when type in [:binary_id, :uuid] do
+    case Application.get_env(:ecto_sqlite3, :binary_id_type, :string) do
+      :string ->
+        ["CAST(", expr(expr, sources, query), " AS ", column_type(type, query), ?)]
+
+      :binary ->
+        [expr(expr, sources, query)]
+    end
+  end
+
   def expr(%Ecto.Query.Tagged{value: other, type: type}, sources, query)
       when type in [:decimal, :float] do
     ["CAST(", expr(other, sources, query), " AS REAL)"]

--- a/lib/ecto/adapters/sqlite3/connection.ex
+++ b/lib/ecto/adapters/sqlite3/connection.ex
@@ -1431,11 +1431,20 @@ defmodule Ecto.Adapters.SQLite3.Connection do
     [?x, ?', hex, ?']
   end
 
-  def expr(%Ecto.Query.Tagged{value: {:^, _, [_]} = expr, type: type}, sources, query)
-      when type in [:binary_id, :uuid] do
+  def expr(%Ecto.Query.Tagged{value: expr, type: :binary_id}, sources, query) do
     case Application.get_env(:ecto_sqlite3, :binary_id_type, :string) do
       :string ->
-        ["CAST(", expr(expr, sources, query), " AS ", column_type(type, query), ?)]
+        ["CAST(", expr(expr, sources, query), " AS ", column_type(:string, query), ?)]
+
+      :binary ->
+        [expr(expr, sources, query)]
+    end
+  end
+
+  def expr(%Ecto.Query.Tagged{value: expr, type: :uuid}, sources, query) do
+    case Application.get_env(:ecto_sqlite3, :uuid_type, :string) do
+      :string ->
+        ["CAST(", expr(expr, sources, query), " AS ", column_type(:string, query), ?)]
 
       :binary ->
         [expr(expr, sources, query)]

--- a/test/ecto/integration/uuid_test.exs
+++ b/test/ecto/integration/uuid_test.exs
@@ -39,18 +39,28 @@ defmodule Ecto.Integration.UUIDTest do
 
   test "handles uuid casting with binary format" do
     Application.put_env(:ecto_sqlite3, :uuid_type, :binary)
+    Application.put_env(:ecto_sqlite3, :binary_id_type, :binary)
 
     external_id = Ecto.UUID.generate()
-    TestRepo.insert!(%Product{external_id: external_id})
-    product = TestRepo.one(from p in Product, where: p.external_id == type(^external_id, Ecto.UUID))
+    TestRepo.insert!(%Product{external_id: external_id, bid: external_id})
+
+    product = TestRepo.one(from(p in Product, where: p.external_id == type(p.bid, Ecto.UUID)))
+    assert %{external_id: ^external_id} = product
+
+    product = TestRepo.one(from(p in Product, where: p.external_id == type(^external_id, Ecto.UUID)))
     assert %{external_id: ^external_id} = product
   end
 
   test "handles binary_id casting with binary format" do
+    Application.put_env(:ecto_sqlite3, :uuid_type, :binary)
     Application.put_env(:ecto_sqlite3, :binary_id_type, :binary)
 
     bid = Ecto.UUID.generate()
-    TestRepo.insert!(%Product{bid: bid})
+    TestRepo.insert!(%Product{bid: bid, external_id: bid})
+
+    product = TestRepo.one(from(p in Product, where: p.bid == type(p.external_id, :binary_id)))
+    assert %{bid: ^bid} = product
+
     product = TestRepo.one(from p in Product, where: p.bid == type(^bid, :binary_id))
     assert %{bid: ^bid} = product
   end

--- a/test/ecto/integration/uuid_test.exs
+++ b/test/ecto/integration/uuid_test.exs
@@ -44,10 +44,16 @@ defmodule Ecto.Integration.UUIDTest do
     external_id = Ecto.UUID.generate()
     TestRepo.insert!(%Product{external_id: external_id, bid: external_id})
 
-    product = TestRepo.one(from(p in Product, where: p.external_id == type(p.bid, Ecto.UUID)))
+    product =
+      TestRepo.one(from(p in Product, where: p.external_id == type(p.bid, Ecto.UUID)))
+
     assert %{external_id: ^external_id} = product
 
-    product = TestRepo.one(from(p in Product, where: p.external_id == type(^external_id, Ecto.UUID)))
+    product =
+      TestRepo.one(
+        from(p in Product, where: p.external_id == type(^external_id, Ecto.UUID))
+      )
+
     assert %{external_id: ^external_id} = product
   end
 
@@ -58,10 +64,12 @@ defmodule Ecto.Integration.UUIDTest do
     bid = Ecto.UUID.generate()
     TestRepo.insert!(%Product{bid: bid, external_id: bid})
 
-    product = TestRepo.one(from(p in Product, where: p.bid == type(p.external_id, :binary_id)))
+    product =
+      TestRepo.one(from(p in Product, where: p.bid == type(p.external_id, :binary_id)))
+
     assert %{bid: ^bid} = product
 
-    product = TestRepo.one(from p in Product, where: p.bid == type(^bid, :binary_id))
+    product = TestRepo.one(from(p in Product, where: p.bid == type(^bid, :binary_id)))
     assert %{bid: ^bid} = product
   end
 end

--- a/test/ecto/integration/uuid_test.exs
+++ b/test/ecto/integration/uuid_test.exs
@@ -4,6 +4,8 @@ defmodule Ecto.Integration.UUIDTest do
   alias Ecto.Integration.TestRepo
   alias EctoSQLite3.Schemas.Product
 
+  import Ecto.Query, only: [from: 2]
+
   setup do
     Application.put_env(:ecto_sqlite3, :uuid_type, :string)
     on_exit(fn -> Application.put_env(:ecto_sqlite3, :uuid_type, :string) end)
@@ -33,5 +35,23 @@ defmodule Ecto.Integration.UUIDTest do
     found = TestRepo.get(Product, product.id)
     assert found
     assert found.external_id == external_id
+  end
+
+  test "handles uuid casting with binary format" do
+    Application.put_env(:ecto_sqlite3, :uuid_type, :binary)
+
+    external_id = Ecto.UUID.generate()
+    TestRepo.insert!(%Product{external_id: external_id})
+    product = TestRepo.one(from p in Product, where: p.external_id == type(^external_id, Ecto.UUID))
+    assert %{external_id: ^external_id} = product
+  end
+
+  test "handles binary_id casting with binary format" do
+    Application.put_env(:ecto_sqlite3, :binary_id_type, :binary)
+
+    bid = Ecto.UUID.generate()
+    TestRepo.insert!(%Product{bid: bid})
+    product = TestRepo.one(from p in Product, where: p.bid == type(^bid, :binary_id))
+    assert %{bid: ^bid} = product
   end
 end

--- a/test/support/migration.ex
+++ b/test/support/migration.ex
@@ -28,6 +28,7 @@ defmodule EctoSQLite3.Integration.Migration do
       add(:name, :string)
       add(:description, :text)
       add(:external_id, :uuid)
+      add(:bid, :binary_id)
       add(:tags, {:array, :string})
       add(:approved_at, :naive_datetime)
       add(:price, :decimal)

--- a/test/support/schemas/product.ex
+++ b/test/support/schemas/product.ex
@@ -11,6 +11,7 @@ defmodule EctoSQLite3.Schemas.Product do
     field(:name, :string)
     field(:description, :string)
     field(:external_id, Ecto.UUID)
+    field(:bid, :binary_id)
     field(:tags, {:array, :string}, default: [])
     field(:approved_at, :naive_datetime)
     field(:price, :decimal)


### PR DESCRIPTION
I think this solves your issue here: https://github.com/elixir-sqlite/ecto_sqlite3/issues/119

I'm not too familiar with SQLite but from what I can tell from the tests it doesn't like it when `cast(_ as blob)` is used. It seems to work when the casting is removed.