### PR TITLE
Support DDL transactions

### DIFF
--- a/integration_test/migrations_test.exs
+++ b/integration_test/migrations_test.exs
@@ -1,0 +1,100 @@
+defmodule Ecto.Integration.MigrationsTest do
+  use ExUnit.Case, async: true
+
+  alias Ecto.Integration.PoolRepo
+  import ExUnit.CaptureLog
+
+  @moduletag :capture_log
+  @base_migration 3_000_000
+
+  defmodule DuplicateTableMigration do
+    use Ecto.Migration
+
+    def change do
+      create_if_not_exists table(:duplicate_table)
+      create_if_not_exists table(:duplicate_table)
+    end
+  end
+
+  defmodule NormalMigration do
+    use Ecto.Migration
+
+    def change do
+      create_if_not_exists table(:log_mode_table)
+    end
+  end
+
+  defmodule IndexMigration do
+    use Ecto.Migration
+    @disable_ddl_transaction true
+
+    def change do
+      create_if_not_exists table(:index_table) do
+        add :name, :string
+        add :custom_id, :uuid
+        timestamps()
+      end
+
+      create_if_not_exists index(:index_table, [:name], concurrently: true)
+    end
+  end
+
+  describe "Migrator" do
+    @create_table_sql ~s(CREATE TABLE IF NOT EXISTS "log_mode_table")
+    @create_table_log "create table if not exists log_mode_table"
+    @drop_table_sql ~s(DROP TABLE IF EXISTS "log_mode_table")
+    @drop_table_log "drop table if exists log_mode_table"
+    @version_insert ~s(INSERT INTO "schema_migrations")
+    @version_delete ~s(DELETE FROM "schema_migrations")
+
+    test "logs locking and transaction commands" do
+      num = @base_migration + System.unique_integer([:positive])
+      up_log =
+        capture_log(fn ->
+          Ecto.Migrator.up(PoolRepo, num, NormalMigration, log_migrator_sql: :info, log_migrations_sql: :info, log: :info)
+        end)
+
+      assert up_log =~ "begin []"
+      assert up_log =~ @create_table_sql
+      assert up_log =~ @create_table_log
+      assert up_log =~ @version_insert
+      assert up_log =~ "commit []"
+
+      down_log =
+        capture_log(fn ->
+          Ecto.Migrator.down(PoolRepo, num, NormalMigration, log_migrator_sql: :info, log_migrations_sql: :info, log: :info)
+        end)
+
+      assert down_log =~ "begin []"
+      assert down_log =~ @drop_table_sql
+      assert down_log =~ @drop_table_log
+      assert down_log =~ @version_delete
+      assert down_log =~ "commit []"
+    end
+
+    test "does not log sql when log is default" do
+      num = @base_migration + System.unique_integer([:positive])
+      up_log =
+        capture_log(fn ->
+          Ecto.Migrator.up(PoolRepo, num, NormalMigration, log: :info)
+        end)
+
+      refute up_log =~ "begin []"
+      refute up_log =~ @create_table_sql
+      assert up_log =~ @create_table_log
+      refute up_log =~ @version_insert
+      refute up_log =~ "commit []"
+
+      down_log =
+        capture_log(fn ->
+          Ecto.Migrator.down(PoolRepo, num, NormalMigration, log: :info)
+        end)
+
+      refute down_log =~ "begin []"
+      refute down_log =~ @drop_table_sql
+      assert down_log =~ @drop_table_log
+      refute down_log =~ @version_delete
+      refute down_log =~ "commit []"
+    end
+  end
+end

--- a/lib/ecto/adapters/sqlite3.ex
+++ b/lib/ecto/adapters/sqlite3.ex
@@ -233,7 +233,7 @@ defmodule Ecto.Adapters.SQLite3 do
   end
 
   @impl Ecto.Adapter.Migration
-  def supports_ddl_transaction?, do: false
+  def supports_ddl_transaction?, do: true
 
   @impl Ecto.Adapter.Migration
   def lock_for_migrations(_meta, _options, fun) do


### PR DESCRIPTION
Closes part of https://github.com/elixir-sqlite/ecto_sqlite3/issues/87.

It doesn't seem to me like anything special needs to be done to support DDL transactions for SQLite. The tests were copied from Ecto SQL and seem to pass with no issue.

For the other part of the issue, locking to prevent concurrent migrations, I don't think anything can be done as is. Ecto requires a separate transaction to hold the lock, independent of the transaction used to perform the migration. This is to allow users the ability to lock even if their migration command cannot be run inside of a transaction. 

From what I can tell this is not compatible with how locks work in SQLite. It seems the same transaction has to hold the lock and do the writing. There's no mutually exclusive lock that can be held that will allow a subsequent transaction to perform a DDL statement, from what I can see.

I don't think it's completely hopeless. But I just have to figure out a good proposal for Ecto for an option to allow everything to be in one transaction.