### PR TITLE
Add support for decimal_encode(nil)

### DIFF
--- a/lib/ecto/adapters/sqlite3/codec.ex
+++ b/lib/ecto/adapters/sqlite3/codec.ex
@@ -98,11 +98,11 @@ defmodule Ecto.Adapters.SQLite3.Codec do
   def bool_encode(false), do: {:ok, 0}
   def bool_encode(true), do: {:ok, 1}
 
+  def decimal_encode(nil), do: {:ok, nil}
+
   def decimal_encode(%Decimal{} = x) do
     {:ok, Decimal.to_string(x, :normal)}
   end
-
-  # def decimal_encode(x), do: {:ok, x}
 
   def time_encode(value) do
     {:ok, value}

--- a/test/ecto/adapters/sqlite3/codec_test.exs
+++ b/test/ecto/adapters/sqlite3/codec_test.exs
@@ -81,6 +81,17 @@ defmodule Ecto.Adapters.SQLite3.CodecTest do
     end
   end
 
+  describe ".decimal_encode/1" do
+    test "nil" do
+      {:ok, nil} = Codec.decimal_encode(nil)
+    end
+
+    test "decimal" do
+      decimal = Decimal.new("2.5")
+      {:ok, "2.5"} = Codec.decimal_encode(decimal)
+    end
+  end
+
   describe ".time_decode/1" do
     test "nil" do
       {:ok, nil} = Codec.time_decode(nil)


### PR DESCRIPTION
It's already possible to decode nil, but encode with nil was not implemented. This cause some failing tests after upgrading my app to the latest ecto version. They are fixed after applying this changes.