### PR TITLE
Update insertion benchmark

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -38,6 +38,6 @@ script instead of `bench/bench_helper.exs`.
 The easiest way to setup mysql and postgresql for the benchmarks is via Docker. Run the following commands to get an instance of each running.
 
 ```
-docker run -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=yes mysql:5.7
+docker run -p 3306:3306 -e MYSQL_ALLOW_EMPTY_PASSWORD=yes mysql:8
 docker run -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:13.2
 ```

--- a/bench/README.md
+++ b/bench/README.md
@@ -18,14 +18,8 @@ need PostgreSQL and MySQL up and running.
 
 To run the benchmarks tests just type in the console:
 
-```
-# POSIX-compatible shells
-$ MIX_ENV=bench mix run bench/bench_helper.exs
-```
-
-```
-# other shells
-$ env MIX_ENV=bench mix run bench/bench_helper.exs
+```sh
+mix run bench/bench_helper.exs
 ```
 
 Benchmarks are inside the `scripts/` directory and are divided into two

--- a/bench/results/all.md
+++ b/bench/results/all.md
@@ -1,0 +1,119 @@
+Benchmark
+
+Benchmark run from 2024-05-04 10:50:11.956493Z UTC
+
+## System
+
+Benchmark suite executing on the following system:
+
+<table style="width: 1%">
+  <tr>
+    <th style="width: 1%; white-space: nowrap">Operating System</th>
+    <td>macOS</td>
+  </tr><tr>
+    <th style="white-space: nowrap">CPU Information</th>
+    <td style="white-space: nowrap">Apple M3 Max</td>
+  </tr><tr>
+    <th style="white-space: nowrap">Number of Available Cores</th>
+    <td style="white-space: nowrap">16</td>
+  </tr><tr>
+    <th style="white-space: nowrap">Available Memory</th>
+    <td style="white-space: nowrap">128 GB</td>
+  </tr><tr>
+    <th style="white-space: nowrap">Elixir Version</th>
+    <td style="white-space: nowrap">1.16.2</td>
+  </tr><tr>
+    <th style="white-space: nowrap">Erlang Version</th>
+    <td style="white-space: nowrap">26.2.4</td>
+  </tr>
+</table>
+
+## Configuration
+
+Benchmark suite executing with the following configuration:
+
+<table style="width: 1%">
+  <tr>
+    <th style="width: 1%">:time</th>
+    <td style="white-space: nowrap">10 s</td>
+  </tr><tr>
+    <th>:parallel</th>
+    <td style="white-space: nowrap">1</td>
+  </tr><tr>
+    <th>:warmup</th>
+    <td style="white-space: nowrap">2 s</td>
+  </tr>
+</table>
+
+## Statistics
+
+
+
+Run Time
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">IPS</th>
+    <th style="text-align: right">Average</th>
+    <th style="text-align: right">Devitation</th>
+    <th style="text-align: right">Median</th>
+    <th style="text-align: right">99th&nbsp;%</th>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">MyXQL Repo.all/2</td>
+    <td style="white-space: nowrap; text-align: right">639.68</td>
+    <td style="white-space: nowrap; text-align: right">1.56 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;12.01%</td>
+    <td style="white-space: nowrap; text-align: right">1.54 ms</td>
+    <td style="white-space: nowrap; text-align: right">2.20 ms</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">SQLite3 Repo.all/2</td>
+    <td style="white-space: nowrap; text-align: right">465.99</td>
+    <td style="white-space: nowrap; text-align: right">2.15 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;4.82%</td>
+    <td style="white-space: nowrap; text-align: right">2.13 ms</td>
+    <td style="white-space: nowrap; text-align: right">2.43 ms</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Pg Repo.all/2</td>
+    <td style="white-space: nowrap; text-align: right">214.16</td>
+    <td style="white-space: nowrap; text-align: right">4.67 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;12.05%</td>
+    <td style="white-space: nowrap; text-align: right">4.66 ms</td>
+    <td style="white-space: nowrap; text-align: right">5.86 ms</td>
+  </tr>
+
+</table>
+
+
+Run Time Comparison
+
+<table style="width: 1%">
+  <tr>
+    <th>Name</th>
+    <th style="text-align: right">IPS</th>
+    <th style="text-align: right">Slower</th>
+  <tr>
+    <td style="white-space: nowrap">MyXQL Repo.all/2</td>
+    <td style="white-space: nowrap;text-align: right">639.68</td>
+    <td>&nbsp;</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">SQLite3 Repo.all/2</td>
+    <td style="white-space: nowrap; text-align: right">465.99</td>
+    <td style="white-space: nowrap; text-align: right">1.37x</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Pg Repo.all/2</td>
+    <td style="white-space: nowrap; text-align: right">214.16</td>
+    <td style="white-space: nowrap; text-align: right">2.99x</td>
+  </tr>
+
+</table>

--- a/bench/results/insert.md
+++ b/bench/results/insert.md
@@ -1,7 +1,6 @@
+Benchmark
 
-# Benchmark
-
-Benchmark run from 2021-03-24 02:05:58.706995Z UTC
+Benchmark run from 2024-05-04 10:49:35.563150Z UTC
 
 ## System
 
@@ -10,22 +9,22 @@ Benchmark suite executing on the following system:
 <table style="width: 1%">
   <tr>
     <th style="width: 1%; white-space: nowrap">Operating System</th>
-    <td>Linux</td>
+    <td>macOS</td>
   </tr><tr>
     <th style="white-space: nowrap">CPU Information</th>
-    <td style="white-space: nowrap">AMD Ryzen 7 PRO 4750U with Radeon Graphics</td>
+    <td style="white-space: nowrap">Apple M3 Max</td>
   </tr><tr>
     <th style="white-space: nowrap">Number of Available Cores</th>
     <td style="white-space: nowrap">16</td>
   </tr><tr>
     <th style="white-space: nowrap">Available Memory</th>
-    <td style="white-space: nowrap">14.92 GB</td>
+    <td style="white-space: nowrap">128 GB</td>
   </tr><tr>
     <th style="white-space: nowrap">Elixir Version</th>
-    <td style="white-space: nowrap">1.11.3</td>
+    <td style="white-space: nowrap">1.16.2</td>
   </tr><tr>
     <th style="white-space: nowrap">Erlang Version</th>
-    <td style="white-space: nowrap">23.2.6</td>
+    <td style="white-space: nowrap">26.2.4</td>
   </tr>
 </table>
 
@@ -50,7 +49,6 @@ Benchmark suite executing with the following configuration:
 
 
 
-
 __Input: Changeset__
 
 Run Time
@@ -67,35 +65,35 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">SQLite3 Insert</td>
-    <td style="white-space: nowrap; text-align: right">7218.07</td>
-    <td style="white-space: nowrap; text-align: right">0.139 ms</td>
-    <td style="white-space: nowrap; text-align: right">±43.60%</td>
-    <td style="white-space: nowrap; text-align: right">0.123 ms</td>
-    <td style="white-space: nowrap; text-align: right">0.37 ms</td>
+    <td style="white-space: nowrap; text-align: right">26.72 K</td>
+    <td style="white-space: nowrap; text-align: right">37.42 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;89.66%</td>
+    <td style="white-space: nowrap; text-align: right">32.88 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">74.21 &micro;s</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Pg Insert</td>
-    <td style="white-space: nowrap; text-align: right">421.57</td>
-    <td style="white-space: nowrap; text-align: right">2.37 ms</td>
-    <td style="white-space: nowrap; text-align: right">±12.13%</td>
-    <td style="white-space: nowrap; text-align: right">2.37 ms</td>
-    <td style="white-space: nowrap; text-align: right">2.90 ms</td>
+    <td style="white-space: nowrap; text-align: right">9.65 K</td>
+    <td style="white-space: nowrap; text-align: right">103.63 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;68.38%</td>
+    <td style="white-space: nowrap; text-align: right">102.75 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">177.39 &micro;s</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">MyXQL Insert</td>
-    <td style="white-space: nowrap; text-align: right">284.25</td>
-    <td style="white-space: nowrap; text-align: right">3.52 ms</td>
-    <td style="white-space: nowrap; text-align: right">±13.34%</td>
-    <td style="white-space: nowrap; text-align: right">3.53 ms</td>
-    <td style="white-space: nowrap; text-align: right">5.05 ms</td>
+    <td style="white-space: nowrap; text-align: right">5.49 K</td>
+    <td style="white-space: nowrap; text-align: right">182.25 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;49.23%</td>
+    <td style="white-space: nowrap; text-align: right">182.33 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">233.08 &micro;s</td>
   </tr>
 
 </table>
 
 
-Comparison
+Run Time Comparison
 
 <table style="width: 1%">
   <tr>
@@ -104,27 +102,25 @@ Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">SQLite3 Insert</td>
-    <td style="white-space: nowrap;text-align: right">7218.07</td>
+    <td style="white-space: nowrap;text-align: right">26.72 K</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Pg Insert</td>
-    <td style="white-space: nowrap; text-align: right">421.57</td>
-    <td style="white-space: nowrap; text-align: right">17.12x</td>
+    <td style="white-space: nowrap; text-align: right">9.65 K</td>
+    <td style="white-space: nowrap; text-align: right">2.77x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">MyXQL Insert</td>
-    <td style="white-space: nowrap; text-align: right">284.25</td>
-    <td style="white-space: nowrap; text-align: right">25.39x</td>
+    <td style="white-space: nowrap; text-align: right">5.49 K</td>
+    <td style="white-space: nowrap; text-align: right">4.87x</td>
   </tr>
 
 </table>
 
 
-
-<hr/>
 
 
 __Input: Struct__
@@ -143,35 +139,35 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">SQLite3 Insert</td>
-    <td style="white-space: nowrap; text-align: right">7765.76</td>
-    <td style="white-space: nowrap; text-align: right">0.129 ms</td>
-    <td style="white-space: nowrap; text-align: right">±32.88%</td>
-    <td style="white-space: nowrap; text-align: right">0.122 ms</td>
-    <td style="white-space: nowrap; text-align: right">0.28 ms</td>
+    <td style="white-space: nowrap; text-align: right">26.71 K</td>
+    <td style="white-space: nowrap; text-align: right">37.44 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;87.15%</td>
+    <td style="white-space: nowrap; text-align: right">32.92 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">70.50 &micro;s</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Pg Insert</td>
-    <td style="white-space: nowrap; text-align: right">422.86</td>
-    <td style="white-space: nowrap; text-align: right">2.36 ms</td>
-    <td style="white-space: nowrap; text-align: right">±10.49%</td>
-    <td style="white-space: nowrap; text-align: right">2.36 ms</td>
-    <td style="white-space: nowrap; text-align: right">3.02 ms</td>
+    <td style="white-space: nowrap; text-align: right">9.34 K</td>
+    <td style="white-space: nowrap; text-align: right">107.08 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;13.80%</td>
+    <td style="white-space: nowrap; text-align: right">106.87 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">132.46 &micro;s</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">MyXQL Insert</td>
-    <td style="white-space: nowrap; text-align: right">274.00</td>
-    <td style="white-space: nowrap; text-align: right">3.65 ms</td>
-    <td style="white-space: nowrap; text-align: right">±38.43%</td>
-    <td style="white-space: nowrap; text-align: right">3.59 ms</td>
-    <td style="white-space: nowrap; text-align: right">4.75 ms</td>
+    <td style="white-space: nowrap; text-align: right">5.67 K</td>
+    <td style="white-space: nowrap; text-align: right">176.45 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;70.69%</td>
+    <td style="white-space: nowrap; text-align: right">176.79 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">234.70 &micro;s</td>
   </tr>
 
 </table>
 
 
-Comparison
+Run Time Comparison
 
 <table style="width: 1%">
   <tr>
@@ -180,25 +176,20 @@ Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">SQLite3 Insert</td>
-    <td style="white-space: nowrap;text-align: right">7765.76</td>
+    <td style="white-space: nowrap;text-align: right">26.71 K</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Pg Insert</td>
-    <td style="white-space: nowrap; text-align: right">422.86</td>
-    <td style="white-space: nowrap; text-align: right">18.37x</td>
+    <td style="white-space: nowrap; text-align: right">9.34 K</td>
+    <td style="white-space: nowrap; text-align: right">2.86x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">MyXQL Insert</td>
-    <td style="white-space: nowrap; text-align: right">274.00</td>
-    <td style="white-space: nowrap; text-align: right">28.34x</td>
+    <td style="white-space: nowrap; text-align: right">5.67 K</td>
+    <td style="white-space: nowrap; text-align: right">4.71x</td>
   </tr>
 
 </table>
-
-
-
-<hr/>
-

--- a/bench/results/load.md
+++ b/bench/results/load.md
@@ -1,7 +1,6 @@
+Benchmark
 
-# Benchmark
-
-Benchmark run from 2021-03-24 01:58:24.995583Z UTC
+Benchmark run from 2024-05-04 10:39:52.658755Z UTC
 
 ## System
 
@@ -10,22 +9,22 @@ Benchmark suite executing on the following system:
 <table style="width: 1%">
   <tr>
     <th style="width: 1%; white-space: nowrap">Operating System</th>
-    <td>Linux</td>
+    <td>macOS</td>
   </tr><tr>
     <th style="white-space: nowrap">CPU Information</th>
-    <td style="white-space: nowrap">AMD Ryzen 7 PRO 4750U with Radeon Graphics</td>
+    <td style="white-space: nowrap">Apple M3 Max</td>
   </tr><tr>
     <th style="white-space: nowrap">Number of Available Cores</th>
     <td style="white-space: nowrap">16</td>
   </tr><tr>
     <th style="white-space: nowrap">Available Memory</th>
-    <td style="white-space: nowrap">14.92 GB</td>
+    <td style="white-space: nowrap">128 GB</td>
   </tr><tr>
     <th style="white-space: nowrap">Elixir Version</th>
-    <td style="white-space: nowrap">1.11.3</td>
+    <td style="white-space: nowrap">1.16.2</td>
   </tr><tr>
     <th style="white-space: nowrap">Erlang Version</th>
-    <td style="white-space: nowrap">23.2.6</td>
+    <td style="white-space: nowrap">26.2.4</td>
   </tr>
 </table>
 
@@ -50,7 +49,6 @@ Benchmark suite executing with the following configuration:
 
 
 
-
 __Input: Big 1 Million__
 
 Run Time
@@ -66,36 +64,36 @@ Run Time
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">SQLite3 Loader</td>
-    <td style="white-space: nowrap; text-align: right">0.35</td>
-    <td style="white-space: nowrap; text-align: right">2.82 s</td>
-    <td style="white-space: nowrap; text-align: right">±15.78%</td>
-    <td style="white-space: nowrap; text-align: right">2.82 s</td>
-    <td style="white-space: nowrap; text-align: right">3.13 s</td>
+    <td style="white-space: nowrap">MyXQL Loader</td>
+    <td style="white-space: nowrap; text-align: right">1.90</td>
+    <td style="white-space: nowrap; text-align: right">526.95 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;7.52%</td>
+    <td style="white-space: nowrap; text-align: right">520.79 ms</td>
+    <td style="white-space: nowrap; text-align: right">590.85 ms</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Pg Loader</td>
-    <td style="white-space: nowrap; text-align: right">0.34</td>
-    <td style="white-space: nowrap; text-align: right">2.92 s</td>
-    <td style="white-space: nowrap; text-align: right">±17.97%</td>
-    <td style="white-space: nowrap; text-align: right">2.92 s</td>
-    <td style="white-space: nowrap; text-align: right">3.29 s</td>
+    <td style="white-space: nowrap; text-align: right">1.89</td>
+    <td style="white-space: nowrap; text-align: right">527.72 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;7.17%</td>
+    <td style="white-space: nowrap; text-align: right">523.29 ms</td>
+    <td style="white-space: nowrap; text-align: right">589.90 ms</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">MyXQL Loader</td>
-    <td style="white-space: nowrap; text-align: right">0.33</td>
-    <td style="white-space: nowrap; text-align: right">2.99 s</td>
-    <td style="white-space: nowrap; text-align: right">±13.08%</td>
-    <td style="white-space: nowrap; text-align: right">2.99 s</td>
-    <td style="white-space: nowrap; text-align: right">3.26 s</td>
+    <td style="white-space: nowrap">SQLite3 Loader</td>
+    <td style="white-space: nowrap; text-align: right">1.89</td>
+    <td style="white-space: nowrap; text-align: right">529.12 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;7.67%</td>
+    <td style="white-space: nowrap; text-align: right">522.49 ms</td>
+    <td style="white-space: nowrap; text-align: right">594.22 ms</td>
   </tr>
 
 </table>
 
 
-Comparison
+Run Time Comparison
 
 <table style="width: 1%">
   <tr>
@@ -103,28 +101,26 @@ Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">SQLite3 Loader</td>
-    <td style="white-space: nowrap;text-align: right">0.35</td>
+    <td style="white-space: nowrap">MyXQL Loader</td>
+    <td style="white-space: nowrap;text-align: right">1.90</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Pg Loader</td>
-    <td style="white-space: nowrap; text-align: right">0.34</td>
-    <td style="white-space: nowrap; text-align: right">1.04x</td>
+    <td style="white-space: nowrap; text-align: right">1.89</td>
+    <td style="white-space: nowrap; text-align: right">1.0x</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">MyXQL Loader</td>
-    <td style="white-space: nowrap; text-align: right">0.33</td>
-    <td style="white-space: nowrap; text-align: right">1.06x</td>
+    <td style="white-space: nowrap">SQLite3 Loader</td>
+    <td style="white-space: nowrap; text-align: right">1.89</td>
+    <td style="white-space: nowrap; text-align: right">1.0x</td>
   </tr>
 
 </table>
 
 
-
-<hr/>
 
 
 __Input: Date attr__
@@ -142,36 +138,36 @@ Run Time
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Pg Loader</td>
-    <td style="white-space: nowrap; text-align: right">4.61</td>
-    <td style="white-space: nowrap; text-align: right">217.08 ms</td>
-    <td style="white-space: nowrap; text-align: right">±13.97%</td>
-    <td style="white-space: nowrap; text-align: right">214.42 ms</td>
-    <td style="white-space: nowrap; text-align: right">271.56 ms</td>
+    <td style="white-space: nowrap">MyXQL Loader</td>
+    <td style="white-space: nowrap; text-align: right">26.37</td>
+    <td style="white-space: nowrap; text-align: right">37.93 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;7.64%</td>
+    <td style="white-space: nowrap; text-align: right">37.53 ms</td>
+    <td style="white-space: nowrap; text-align: right">48.13 ms</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">MyXQL Loader</td>
-    <td style="white-space: nowrap; text-align: right">4.56</td>
-    <td style="white-space: nowrap; text-align: right">219.25 ms</td>
-    <td style="white-space: nowrap; text-align: right">±18.19%</td>
-    <td style="white-space: nowrap; text-align: right">210.43 ms</td>
-    <td style="white-space: nowrap; text-align: right">300.02 ms</td>
+    <td style="white-space: nowrap">Pg Loader</td>
+    <td style="white-space: nowrap; text-align: right">25.98</td>
+    <td style="white-space: nowrap; text-align: right">38.49 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;7.63%</td>
+    <td style="white-space: nowrap; text-align: right">38.31 ms</td>
+    <td style="white-space: nowrap; text-align: right">48.20 ms</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">SQLite3 Loader</td>
-    <td style="white-space: nowrap; text-align: right">4.49</td>
-    <td style="white-space: nowrap; text-align: right">222.95 ms</td>
-    <td style="white-space: nowrap; text-align: right">±15.03%</td>
-    <td style="white-space: nowrap; text-align: right">232.42 ms</td>
-    <td style="white-space: nowrap; text-align: right">266.39 ms</td>
+    <td style="white-space: nowrap; text-align: right">25.91</td>
+    <td style="white-space: nowrap; text-align: right">38.59 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;7.51%</td>
+    <td style="white-space: nowrap; text-align: right">38.46 ms</td>
+    <td style="white-space: nowrap; text-align: right">48.29 ms</td>
   </tr>
 
 </table>
 
 
-Comparison
+Run Time Comparison
 
 <table style="width: 1%">
   <tr>
@@ -179,28 +175,26 @@ Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Pg Loader</td>
-    <td style="white-space: nowrap;text-align: right">4.61</td>
+    <td style="white-space: nowrap">MyXQL Loader</td>
+    <td style="white-space: nowrap;text-align: right">26.37</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">MyXQL Loader</td>
-    <td style="white-space: nowrap; text-align: right">4.56</td>
+    <td style="white-space: nowrap">Pg Loader</td>
+    <td style="white-space: nowrap; text-align: right">25.98</td>
     <td style="white-space: nowrap; text-align: right">1.01x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">SQLite3 Loader</td>
-    <td style="white-space: nowrap; text-align: right">4.49</td>
-    <td style="white-space: nowrap; text-align: right">1.03x</td>
+    <td style="white-space: nowrap; text-align: right">25.91</td>
+    <td style="white-space: nowrap; text-align: right">1.02x</td>
   </tr>
 
 </table>
 
 
-
-<hr/>
 
 
 __Input: Medium 100 Thousand__
@@ -219,35 +213,35 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">MyXQL Loader</td>
-    <td style="white-space: nowrap; text-align: right">4.53</td>
-    <td style="white-space: nowrap; text-align: right">220.75 ms</td>
-    <td style="white-space: nowrap; text-align: right">±15.57%</td>
-    <td style="white-space: nowrap; text-align: right">209.17 ms</td>
-    <td style="white-space: nowrap; text-align: right">287.22 ms</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Pg Loader</td>
-    <td style="white-space: nowrap; text-align: right">4.40</td>
-    <td style="white-space: nowrap; text-align: right">227.35 ms</td>
-    <td style="white-space: nowrap; text-align: right">±16.30%</td>
-    <td style="white-space: nowrap; text-align: right">222.39 ms</td>
-    <td style="white-space: nowrap; text-align: right">335.90 ms</td>
+    <td style="white-space: nowrap; text-align: right">26.27</td>
+    <td style="white-space: nowrap; text-align: right">38.07 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;5.01%</td>
+    <td style="white-space: nowrap; text-align: right">38.36 ms</td>
+    <td style="white-space: nowrap; text-align: right">42.73 ms</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">SQLite3 Loader</td>
-    <td style="white-space: nowrap; text-align: right">4.35</td>
-    <td style="white-space: nowrap; text-align: right">230.09 ms</td>
-    <td style="white-space: nowrap; text-align: right">±19.61%</td>
-    <td style="white-space: nowrap; text-align: right">236.94 ms</td>
-    <td style="white-space: nowrap; text-align: right">309.96 ms</td>
+    <td style="white-space: nowrap; text-align: right">25.64</td>
+    <td style="white-space: nowrap; text-align: right">39.01 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;5.25%</td>
+    <td style="white-space: nowrap; text-align: right">39.42 ms</td>
+    <td style="white-space: nowrap; text-align: right">43.28 ms</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Pg Loader</td>
+    <td style="white-space: nowrap; text-align: right">25.44</td>
+    <td style="white-space: nowrap; text-align: right">39.31 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;6.97%</td>
+    <td style="white-space: nowrap; text-align: right">39.50 ms</td>
+    <td style="white-space: nowrap; text-align: right">49.12 ms</td>
   </tr>
 
 </table>
 
 
-Comparison
+Run Time Comparison
 
 <table style="width: 1%">
   <tr>
@@ -256,27 +250,25 @@ Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">MyXQL Loader</td>
-    <td style="white-space: nowrap;text-align: right">4.53</td>
+    <td style="white-space: nowrap;text-align: right">26.27</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Pg Loader</td>
-    <td style="white-space: nowrap; text-align: right">4.40</td>
-    <td style="white-space: nowrap; text-align: right">1.03x</td>
+    <td style="white-space: nowrap">SQLite3 Loader</td>
+    <td style="white-space: nowrap; text-align: right">25.64</td>
+    <td style="white-space: nowrap; text-align: right">1.02x</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">SQLite3 Loader</td>
-    <td style="white-space: nowrap; text-align: right">4.35</td>
-    <td style="white-space: nowrap; text-align: right">1.04x</td>
+    <td style="white-space: nowrap">Pg Loader</td>
+    <td style="white-space: nowrap; text-align: right">25.44</td>
+    <td style="white-space: nowrap; text-align: right">1.03x</td>
   </tr>
 
 </table>
 
 
-
-<hr/>
 
 
 __Input: Small 1 Thousand__
@@ -294,36 +286,36 @@ Run Time
   </tr>
 
   <tr>
+    <td style="white-space: nowrap">MyXQL Loader</td>
+    <td style="white-space: nowrap; text-align: right">2.95 K</td>
+    <td style="white-space: nowrap; text-align: right">339.32 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;13.05%</td>
+    <td style="white-space: nowrap; text-align: right">330.33 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">493.99 &micro;s</td>
+  </tr>
+
+  <tr>
     <td style="white-space: nowrap">Pg Loader</td>
-    <td style="white-space: nowrap; text-align: right">883.24</td>
-    <td style="white-space: nowrap; text-align: right">1.13 ms</td>
-    <td style="white-space: nowrap; text-align: right">±62.88%</td>
-    <td style="white-space: nowrap; text-align: right">0.93 ms</td>
-    <td style="white-space: nowrap; text-align: right">2.71 ms</td>
+    <td style="white-space: nowrap; text-align: right">2.92 K</td>
+    <td style="white-space: nowrap; text-align: right">342.75 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;13.24%</td>
+    <td style="white-space: nowrap; text-align: right">332.17 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">499.14 &micro;s</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">SQLite3 Loader</td>
-    <td style="white-space: nowrap; text-align: right">873.53</td>
-    <td style="white-space: nowrap; text-align: right">1.14 ms</td>
-    <td style="white-space: nowrap; text-align: right">±60.06%</td>
-    <td style="white-space: nowrap; text-align: right">0.92 ms</td>
-    <td style="white-space: nowrap; text-align: right">2.90 ms</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">MyXQL Loader</td>
-    <td style="white-space: nowrap; text-align: right">862.33</td>
-    <td style="white-space: nowrap; text-align: right">1.16 ms</td>
-    <td style="white-space: nowrap; text-align: right">±62.27%</td>
-    <td style="white-space: nowrap; text-align: right">0.92 ms</td>
-    <td style="white-space: nowrap; text-align: right">2.77 ms</td>
+    <td style="white-space: nowrap; text-align: right">2.91 K</td>
+    <td style="white-space: nowrap; text-align: right">343.63 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;12.64%</td>
+    <td style="white-space: nowrap; text-align: right">330.21 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">495.04 &micro;s</td>
   </tr>
 
 </table>
 
 
-Comparison
+Run Time Comparison
 
 <table style="width: 1%">
   <tr>
@@ -331,28 +323,26 @@ Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Pg Loader</td>
-    <td style="white-space: nowrap;text-align: right">883.24</td>
+    <td style="white-space: nowrap">MyXQL Loader</td>
+    <td style="white-space: nowrap;text-align: right">2.95 K</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">SQLite3 Loader</td>
-    <td style="white-space: nowrap; text-align: right">873.53</td>
+    <td style="white-space: nowrap">Pg Loader</td>
+    <td style="white-space: nowrap; text-align: right">2.92 K</td>
     <td style="white-space: nowrap; text-align: right">1.01x</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">MyXQL Loader</td>
-    <td style="white-space: nowrap; text-align: right">862.33</td>
-    <td style="white-space: nowrap; text-align: right">1.02x</td>
+    <td style="white-space: nowrap">SQLite3 Loader</td>
+    <td style="white-space: nowrap; text-align: right">2.91 K</td>
+    <td style="white-space: nowrap; text-align: right">1.01x</td>
   </tr>
 
 </table>
 
 
-
-<hr/>
 
 
 __Input: Time attr__
@@ -370,36 +360,36 @@ Run Time
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">SQLite3 Loader</td>
-    <td style="white-space: nowrap; text-align: right">3.40</td>
-    <td style="white-space: nowrap; text-align: right">294.30 ms</td>
-    <td style="white-space: nowrap; text-align: right">±15.60%</td>
-    <td style="white-space: nowrap; text-align: right">281.23 ms</td>
-    <td style="white-space: nowrap; text-align: right">367.65 ms</td>
-  </tr>
-
-  <tr>
     <td style="white-space: nowrap">MyXQL Loader</td>
-    <td style="white-space: nowrap; text-align: right">3.18</td>
-    <td style="white-space: nowrap; text-align: right">314.55 ms</td>
-    <td style="white-space: nowrap; text-align: right">±17.11%</td>
-    <td style="white-space: nowrap; text-align: right">313.35 ms</td>
-    <td style="white-space: nowrap; text-align: right">415.89 ms</td>
+    <td style="white-space: nowrap; text-align: right">21.75</td>
+    <td style="white-space: nowrap; text-align: right">45.98 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;11.17%</td>
+    <td style="white-space: nowrap; text-align: right">45.25 ms</td>
+    <td style="white-space: nowrap; text-align: right">61.90 ms</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Pg Loader</td>
-    <td style="white-space: nowrap; text-align: right">3.03</td>
-    <td style="white-space: nowrap; text-align: right">329.99 ms</td>
-    <td style="white-space: nowrap; text-align: right">±16.46%</td>
-    <td style="white-space: nowrap; text-align: right">321.68 ms</td>
-    <td style="white-space: nowrap; text-align: right">457.42 ms</td>
+    <td style="white-space: nowrap; text-align: right">21.43</td>
+    <td style="white-space: nowrap; text-align: right">46.67 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;10.90%</td>
+    <td style="white-space: nowrap; text-align: right">45.76 ms</td>
+    <td style="white-space: nowrap; text-align: right">61.66 ms</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">SQLite3 Loader</td>
+    <td style="white-space: nowrap; text-align: right">20.72</td>
+    <td style="white-space: nowrap; text-align: right">48.26 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;9.03%</td>
+    <td style="white-space: nowrap; text-align: right">48.63 ms</td>
+    <td style="white-space: nowrap; text-align: right">62.19 ms</td>
   </tr>
 
 </table>
 
 
-Comparison
+Run Time Comparison
 
 <table style="width: 1%">
   <tr>
@@ -407,28 +397,26 @@ Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">SQLite3 Loader</td>
-    <td style="white-space: nowrap;text-align: right">3.40</td>
+    <td style="white-space: nowrap">MyXQL Loader</td>
+    <td style="white-space: nowrap;text-align: right">21.75</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">MyXQL Loader</td>
-    <td style="white-space: nowrap; text-align: right">3.18</td>
-    <td style="white-space: nowrap; text-align: right">1.07x</td>
+    <td style="white-space: nowrap">Pg Loader</td>
+    <td style="white-space: nowrap; text-align: right">21.43</td>
+    <td style="white-space: nowrap; text-align: right">1.01x</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Pg Loader</td>
-    <td style="white-space: nowrap; text-align: right">3.03</td>
-    <td style="white-space: nowrap; text-align: right">1.12x</td>
+    <td style="white-space: nowrap">SQLite3 Loader</td>
+    <td style="white-space: nowrap; text-align: right">20.72</td>
+    <td style="white-space: nowrap; text-align: right">1.05x</td>
   </tr>
 
 </table>
 
 
-
-<hr/>
 
 
 __Input: UUID attr__
@@ -447,35 +435,35 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">SQLite3 Loader</td>
-    <td style="white-space: nowrap; text-align: right">3.61</td>
-    <td style="white-space: nowrap; text-align: right">277.20 ms</td>
-    <td style="white-space: nowrap; text-align: right">±16.59%</td>
-    <td style="white-space: nowrap; text-align: right">266.05 ms</td>
-    <td style="white-space: nowrap; text-align: right">372.08 ms</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">Pg Loader</td>
-    <td style="white-space: nowrap; text-align: right">2.75</td>
-    <td style="white-space: nowrap; text-align: right">363.06 ms</td>
-    <td style="white-space: nowrap; text-align: right">±14.14%</td>
-    <td style="white-space: nowrap; text-align: right">382.70 ms</td>
-    <td style="white-space: nowrap; text-align: right">437.37 ms</td>
+    <td style="white-space: nowrap; text-align: right">23.23</td>
+    <td style="white-space: nowrap; text-align: right">43.06 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;8.19%</td>
+    <td style="white-space: nowrap; text-align: right">41.64 ms</td>
+    <td style="white-space: nowrap; text-align: right">51.14 ms</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">MyXQL Loader</td>
-    <td style="white-space: nowrap; text-align: right">2.73</td>
-    <td style="white-space: nowrap; text-align: right">365.91 ms</td>
-    <td style="white-space: nowrap; text-align: right">±19.81%</td>
-    <td style="white-space: nowrap; text-align: right">367.23 ms</td>
-    <td style="white-space: nowrap; text-align: right">515.29 ms</td>
+    <td style="white-space: nowrap; text-align: right">15.19</td>
+    <td style="white-space: nowrap; text-align: right">65.81 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;7.56%</td>
+    <td style="white-space: nowrap; text-align: right">63.25 ms</td>
+    <td style="white-space: nowrap; text-align: right">76.27 ms</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">Pg Loader</td>
+    <td style="white-space: nowrap; text-align: right">14.89</td>
+    <td style="white-space: nowrap; text-align: right">67.14 ms</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;7.74%</td>
+    <td style="white-space: nowrap; text-align: right">64.12 ms</td>
+    <td style="white-space: nowrap; text-align: right">80.65 ms</td>
   </tr>
 
 </table>
 
 
-Comparison
+Run Time Comparison
 
 <table style="width: 1%">
   <tr>
@@ -484,25 +472,20 @@ Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">SQLite3 Loader</td>
-    <td style="white-space: nowrap;text-align: right">3.61</td>
+    <td style="white-space: nowrap;text-align: right">23.23</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Pg Loader</td>
-    <td style="white-space: nowrap; text-align: right">2.75</td>
-    <td style="white-space: nowrap; text-align: right">1.31x</td>
+    <td style="white-space: nowrap">MyXQL Loader</td>
+    <td style="white-space: nowrap; text-align: right">15.19</td>
+    <td style="white-space: nowrap; text-align: right">1.53x</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">MyXQL Loader</td>
-    <td style="white-space: nowrap; text-align: right">2.73</td>
-    <td style="white-space: nowrap; text-align: right">1.32x</td>
+    <td style="white-space: nowrap">Pg Loader</td>
+    <td style="white-space: nowrap; text-align: right">14.89</td>
+    <td style="white-space: nowrap; text-align: right">1.56x</td>
   </tr>
 
 </table>
-
-
-
-<hr/>
-

--- a/bench/results/to_sql.md
+++ b/bench/results/to_sql.md
@@ -1,7 +1,6 @@
+Benchmark
 
-# Benchmark
-
-Benchmark run from 2021-03-24 02:02:16.278354Z UTC
+Benchmark run from 2024-05-04 10:48:53.108179Z UTC
 
 ## System
 
@@ -10,22 +9,22 @@ Benchmark suite executing on the following system:
 <table style="width: 1%">
   <tr>
     <th style="width: 1%; white-space: nowrap">Operating System</th>
-    <td>Linux</td>
+    <td>macOS</td>
   </tr><tr>
     <th style="white-space: nowrap">CPU Information</th>
-    <td style="white-space: nowrap">AMD Ryzen 7 PRO 4750U with Radeon Graphics</td>
+    <td style="white-space: nowrap">Apple M3 Max</td>
   </tr><tr>
     <th style="white-space: nowrap">Number of Available Cores</th>
     <td style="white-space: nowrap">16</td>
   </tr><tr>
     <th style="white-space: nowrap">Available Memory</th>
-    <td style="white-space: nowrap">14.92 GB</td>
+    <td style="white-space: nowrap">128 GB</td>
   </tr><tr>
     <th style="white-space: nowrap">Elixir Version</th>
-    <td style="white-space: nowrap">1.11.3</td>
+    <td style="white-space: nowrap">1.16.2</td>
   </tr><tr>
     <th style="white-space: nowrap">Erlang Version</th>
-    <td style="white-space: nowrap">23.2.6</td>
+    <td style="white-space: nowrap">26.2.4</td>
   </tr>
 </table>
 
@@ -50,7 +49,6 @@ Benchmark suite executing with the following configuration:
 
 
 
-
 __Input: Complex Query 2 Joins__
 
 Run Time
@@ -66,36 +64,36 @@ Run Time
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">MyXQL Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">105.28 K</td>
-    <td style="white-space: nowrap; text-align: right">9.50 μs</td>
-    <td style="white-space: nowrap; text-align: right">±116.92%</td>
-    <td style="white-space: nowrap; text-align: right">8.66 μs</td>
-    <td style="white-space: nowrap; text-align: right">24.79 μs</td>
-  </tr>
-
-  <tr>
     <td style="white-space: nowrap">Pg Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">96.97 K</td>
-    <td style="white-space: nowrap; text-align: right">10.31 μs</td>
-    <td style="white-space: nowrap; text-align: right">±220.90%</td>
-    <td style="white-space: nowrap; text-align: right">8.66 μs</td>
-    <td style="white-space: nowrap; text-align: right">26.75 μs</td>
+    <td style="white-space: nowrap; text-align: right">382.74 K</td>
+    <td style="white-space: nowrap; text-align: right">2.61 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;374.25%</td>
+    <td style="white-space: nowrap; text-align: right">2.38 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">3.42 &micro;s</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">SQLite3 Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">90.46 K</td>
-    <td style="white-space: nowrap; text-align: right">11.05 μs</td>
-    <td style="white-space: nowrap; text-align: right">±204.34%</td>
-    <td style="white-space: nowrap; text-align: right">8.66 μs</td>
-    <td style="white-space: nowrap; text-align: right">39.53 μs</td>
+    <td style="white-space: nowrap; text-align: right">374.17 K</td>
+    <td style="white-space: nowrap; text-align: right">2.67 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;382.43%</td>
+    <td style="white-space: nowrap; text-align: right">2.46 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">3.42 &micro;s</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">MyXQL Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">360.95 K</td>
+    <td style="white-space: nowrap; text-align: right">2.77 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;360.52%</td>
+    <td style="white-space: nowrap; text-align: right">2.54 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">3.58 &micro;s</td>
   </tr>
 
 </table>
 
 
-Comparison
+Run Time Comparison
 
 <table style="width: 1%">
   <tr>
@@ -103,28 +101,26 @@ Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">MyXQL Query Builder</td>
-    <td style="white-space: nowrap;text-align: right">105.28 K</td>
+    <td style="white-space: nowrap">Pg Query Builder</td>
+    <td style="white-space: nowrap;text-align: right">382.74 K</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Pg Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">96.97 K</td>
-    <td style="white-space: nowrap; text-align: right">1.09x</td>
+    <td style="white-space: nowrap">SQLite3 Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">374.17 K</td>
+    <td style="white-space: nowrap; text-align: right">1.02x</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">SQLite3 Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">90.46 K</td>
-    <td style="white-space: nowrap; text-align: right">1.16x</td>
+    <td style="white-space: nowrap">MyXQL Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">360.95 K</td>
+    <td style="white-space: nowrap; text-align: right">1.06x</td>
   </tr>
 
 </table>
 
 
-
-<hr/>
 
 
 __Input: Complex Query 4 Joins__
@@ -142,36 +138,36 @@ Run Time
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Pg Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">100.25 K</td>
-    <td style="white-space: nowrap; text-align: right">9.97 μs</td>
-    <td style="white-space: nowrap; text-align: right">±92.25%</td>
-    <td style="white-space: nowrap; text-align: right">9.15 μs</td>
-    <td style="white-space: nowrap; text-align: right">23.68 μs</td>
+    <td style="white-space: nowrap">MyXQL Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">342.45 K</td>
+    <td style="white-space: nowrap; text-align: right">2.92 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;313.75%</td>
+    <td style="white-space: nowrap; text-align: right">2.67 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">4.08 &micro;s</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">MyXQL Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">98.47 K</td>
-    <td style="white-space: nowrap; text-align: right">10.16 μs</td>
-    <td style="white-space: nowrap; text-align: right">±88.64%</td>
-    <td style="white-space: nowrap; text-align: right">9.22 μs</td>
-    <td style="white-space: nowrap; text-align: right">28.70 μs</td>
+    <td style="white-space: nowrap">Pg Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">340.76 K</td>
+    <td style="white-space: nowrap; text-align: right">2.93 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;350.68%</td>
+    <td style="white-space: nowrap; text-align: right">2.71 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">3.88 &micro;s</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">SQLite3 Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">90.40 K</td>
-    <td style="white-space: nowrap; text-align: right">11.06 μs</td>
-    <td style="white-space: nowrap; text-align: right">±117.48%</td>
-    <td style="white-space: nowrap; text-align: right">9.22 μs</td>
-    <td style="white-space: nowrap; text-align: right">38.69 μs</td>
+    <td style="white-space: nowrap; text-align: right">336.08 K</td>
+    <td style="white-space: nowrap; text-align: right">2.98 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;328.89%</td>
+    <td style="white-space: nowrap; text-align: right">2.79 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">3.88 &micro;s</td>
   </tr>
 
 </table>
 
 
-Comparison
+Run Time Comparison
 
 <table style="width: 1%">
   <tr>
@@ -179,28 +175,26 @@ Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Pg Query Builder</td>
-    <td style="white-space: nowrap;text-align: right">100.25 K</td>
+    <td style="white-space: nowrap">MyXQL Query Builder</td>
+    <td style="white-space: nowrap;text-align: right">342.45 K</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">MyXQL Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">98.47 K</td>
-    <td style="white-space: nowrap; text-align: right">1.02x</td>
+    <td style="white-space: nowrap">Pg Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">340.76 K</td>
+    <td style="white-space: nowrap; text-align: right">1.0x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">SQLite3 Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">90.40 K</td>
-    <td style="white-space: nowrap; text-align: right">1.11x</td>
+    <td style="white-space: nowrap; text-align: right">336.08 K</td>
+    <td style="white-space: nowrap; text-align: right">1.02x</td>
   </tr>
 
 </table>
 
 
-
-<hr/>
 
 
 __Input: Fetch First Registry__
@@ -218,36 +212,36 @@ Run Time
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Pg Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">173.31 K</td>
-    <td style="white-space: nowrap; text-align: right">5.77 μs</td>
-    <td style="white-space: nowrap; text-align: right">±389.85%</td>
-    <td style="white-space: nowrap; text-align: right">4.47 μs</td>
-    <td style="white-space: nowrap; text-align: right">20.18 μs</td>
+    <td style="white-space: nowrap">MyXQL Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">752.12 K</td>
+    <td style="white-space: nowrap; text-align: right">1.33 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;868.39%</td>
+    <td style="white-space: nowrap; text-align: right">1.17 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">1.63 &micro;s</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">MyXQL Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">173.06 K</td>
-    <td style="white-space: nowrap; text-align: right">5.78 μs</td>
-    <td style="white-space: nowrap; text-align: right">±411.02%</td>
-    <td style="white-space: nowrap; text-align: right">4.82 μs</td>
-    <td style="white-space: nowrap; text-align: right">16.20 μs</td>
+    <td style="white-space: nowrap">Pg Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">721.56 K</td>
+    <td style="white-space: nowrap; text-align: right">1.39 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;820.83%</td>
+    <td style="white-space: nowrap; text-align: right">1.25 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">1.67 &micro;s</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">SQLite3 Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">167.17 K</td>
-    <td style="white-space: nowrap; text-align: right">5.98 μs</td>
-    <td style="white-space: nowrap; text-align: right">±420.59%</td>
-    <td style="white-space: nowrap; text-align: right">4.82 μs</td>
-    <td style="white-space: nowrap; text-align: right">19.42 μs</td>
+    <td style="white-space: nowrap; text-align: right">703.84 K</td>
+    <td style="white-space: nowrap; text-align: right">1.42 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;817.39%</td>
+    <td style="white-space: nowrap; text-align: right">1.29 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">1.71 &micro;s</td>
   </tr>
 
 </table>
 
 
-Comparison
+Run Time Comparison
 
 <table style="width: 1%">
   <tr>
@@ -255,28 +249,26 @@ Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Pg Query Builder</td>
-    <td style="white-space: nowrap;text-align: right">173.31 K</td>
+    <td style="white-space: nowrap">MyXQL Query Builder</td>
+    <td style="white-space: nowrap;text-align: right">752.12 K</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">MyXQL Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">173.06 K</td>
-    <td style="white-space: nowrap; text-align: right">1.0x</td>
+    <td style="white-space: nowrap">Pg Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">721.56 K</td>
+    <td style="white-space: nowrap; text-align: right">1.04x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">SQLite3 Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">167.17 K</td>
-    <td style="white-space: nowrap; text-align: right">1.04x</td>
+    <td style="white-space: nowrap; text-align: right">703.84 K</td>
+    <td style="white-space: nowrap; text-align: right">1.07x</td>
   </tr>
 
 </table>
 
 
-
-<hr/>
 
 
 __Input: Fetch Last Registry__
@@ -294,36 +286,36 @@ Run Time
   </tr>
 
   <tr>
+    <td style="white-space: nowrap">MyXQL Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">731.59 K</td>
+    <td style="white-space: nowrap; text-align: right">1.37 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;795.20%</td>
+    <td style="white-space: nowrap; text-align: right">1.21 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">1.71 &micro;s</td>
+  </tr>
+
+  <tr>
     <td style="white-space: nowrap">Pg Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">177.36 K</td>
-    <td style="white-space: nowrap; text-align: right">5.64 μs</td>
-    <td style="white-space: nowrap; text-align: right">±446.37%</td>
-    <td style="white-space: nowrap; text-align: right">4.47 μs</td>
-    <td style="white-space: nowrap; text-align: right">17.67 μs</td>
+    <td style="white-space: nowrap; text-align: right">716.25 K</td>
+    <td style="white-space: nowrap; text-align: right">1.40 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;814.43%</td>
+    <td style="white-space: nowrap; text-align: right">1.25 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">1.67 &micro;s</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">SQLite3 Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">169.74 K</td>
-    <td style="white-space: nowrap; text-align: right">5.89 μs</td>
-    <td style="white-space: nowrap; text-align: right">±394.73%</td>
-    <td style="white-space: nowrap; text-align: right">4.82 μs</td>
-    <td style="white-space: nowrap; text-align: right">18.16 μs</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">MyXQL Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">162.83 K</td>
-    <td style="white-space: nowrap; text-align: right">6.14 μs</td>
-    <td style="white-space: nowrap; text-align: right">±383.32%</td>
-    <td style="white-space: nowrap; text-align: right">4.82 μs</td>
-    <td style="white-space: nowrap; text-align: right">22.14 μs</td>
+    <td style="white-space: nowrap; text-align: right">707.98 K</td>
+    <td style="white-space: nowrap; text-align: right">1.41 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;839.02%</td>
+    <td style="white-space: nowrap; text-align: right">1.25 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">1.67 &micro;s</td>
   </tr>
 
 </table>
 
 
-Comparison
+Run Time Comparison
 
 <table style="width: 1%">
   <tr>
@@ -331,28 +323,26 @@ Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Pg Query Builder</td>
-    <td style="white-space: nowrap;text-align: right">177.36 K</td>
+    <td style="white-space: nowrap">MyXQL Query Builder</td>
+    <td style="white-space: nowrap;text-align: right">731.59 K</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">SQLite3 Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">169.74 K</td>
-    <td style="white-space: nowrap; text-align: right">1.04x</td>
+    <td style="white-space: nowrap">Pg Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">716.25 K</td>
+    <td style="white-space: nowrap; text-align: right">1.02x</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">MyXQL Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">162.83 K</td>
-    <td style="white-space: nowrap; text-align: right">1.09x</td>
+    <td style="white-space: nowrap">SQLite3 Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">707.98 K</td>
+    <td style="white-space: nowrap; text-align: right">1.03x</td>
   </tr>
 
 </table>
 
 
-
-<hr/>
 
 
 __Input: Ordinary Delete All__
@@ -370,36 +360,36 @@ Run Time
   </tr>
 
   <tr>
+    <td style="white-space: nowrap">MyXQL Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">1.34 M</td>
+    <td style="white-space: nowrap; text-align: right">747.69 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;2442.90%</td>
+    <td style="white-space: nowrap; text-align: right">666 ns</td>
+    <td style="white-space: nowrap; text-align: right">917 ns</td>
+  </tr>
+
+  <tr>
     <td style="white-space: nowrap">Pg Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">335.81 K</td>
-    <td style="white-space: nowrap; text-align: right">2.98 μs</td>
-    <td style="white-space: nowrap; text-align: right">±775.40%</td>
-    <td style="white-space: nowrap; text-align: right">2.03 μs</td>
-    <td style="white-space: nowrap; text-align: right">9.43 μs</td>
+    <td style="white-space: nowrap; text-align: right">1.32 M</td>
+    <td style="white-space: nowrap; text-align: right">758.40 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;2490.71%</td>
+    <td style="white-space: nowrap; text-align: right">667 ns</td>
+    <td style="white-space: nowrap; text-align: right">875 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">SQLite3 Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">325.92 K</td>
-    <td style="white-space: nowrap; text-align: right">3.07 μs</td>
-    <td style="white-space: nowrap; text-align: right">±948.36%</td>
-    <td style="white-space: nowrap; text-align: right">2.02 μs</td>
-    <td style="white-space: nowrap; text-align: right">8.31 μs</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">MyXQL Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">301.67 K</td>
-    <td style="white-space: nowrap; text-align: right">3.31 μs</td>
-    <td style="white-space: nowrap; text-align: right">±832.06%</td>
-    <td style="white-space: nowrap; text-align: right">2.03 μs</td>
-    <td style="white-space: nowrap; text-align: right">11.59 μs</td>
+    <td style="white-space: nowrap; text-align: right">1.31 M</td>
+    <td style="white-space: nowrap; text-align: right">762.71 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;2451.66%</td>
+    <td style="white-space: nowrap; text-align: right">667 ns</td>
+    <td style="white-space: nowrap; text-align: right">875 ns</td>
   </tr>
 
 </table>
 
 
-Comparison
+Run Time Comparison
 
 <table style="width: 1%">
   <tr>
@@ -407,28 +397,26 @@ Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Pg Query Builder</td>
-    <td style="white-space: nowrap;text-align: right">335.81 K</td>
+    <td style="white-space: nowrap">MyXQL Query Builder</td>
+    <td style="white-space: nowrap;text-align: right">1.34 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">SQLite3 Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">325.92 K</td>
-    <td style="white-space: nowrap; text-align: right">1.03x</td>
+    <td style="white-space: nowrap">Pg Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">1.32 M</td>
+    <td style="white-space: nowrap; text-align: right">1.01x</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">MyXQL Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">301.67 K</td>
-    <td style="white-space: nowrap; text-align: right">1.11x</td>
+    <td style="white-space: nowrap">SQLite3 Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">1.31 M</td>
+    <td style="white-space: nowrap; text-align: right">1.02x</td>
   </tr>
 
 </table>
 
 
-
-<hr/>
 
 
 __Input: Ordinary Order By__
@@ -446,36 +434,36 @@ Run Time
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Pg Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">186.48 K</td>
-    <td style="white-space: nowrap; text-align: right">5.36 μs</td>
-    <td style="white-space: nowrap; text-align: right">±400.39%</td>
-    <td style="white-space: nowrap; text-align: right">4.40 μs</td>
-    <td style="white-space: nowrap; text-align: right">17.81 μs</td>
+    <td style="white-space: nowrap">MyXQL Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">742.88 K</td>
+    <td style="white-space: nowrap; text-align: right">1.35 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;918.40%</td>
+    <td style="white-space: nowrap; text-align: right">1.17 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">1.67 &micro;s</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">MyXQL Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">182.02 K</td>
-    <td style="white-space: nowrap; text-align: right">5.49 μs</td>
-    <td style="white-space: nowrap; text-align: right">±402.64%</td>
-    <td style="white-space: nowrap; text-align: right">4.40 μs</td>
-    <td style="white-space: nowrap; text-align: right">17.39 μs</td>
+    <td style="white-space: nowrap">Pg Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">729.59 K</td>
+    <td style="white-space: nowrap; text-align: right">1.37 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;913.47%</td>
+    <td style="white-space: nowrap; text-align: right">1.21 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">1.58 &micro;s</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">SQLite3 Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">172.19 K</td>
-    <td style="white-space: nowrap; text-align: right">5.81 μs</td>
-    <td style="white-space: nowrap; text-align: right">±427.38%</td>
-    <td style="white-space: nowrap; text-align: right">4.47 μs</td>
-    <td style="white-space: nowrap; text-align: right">21.44 μs</td>
+    <td style="white-space: nowrap; text-align: right">721.11 K</td>
+    <td style="white-space: nowrap; text-align: right">1.39 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;918.31%</td>
+    <td style="white-space: nowrap; text-align: right">1.21 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">1.58 &micro;s</td>
   </tr>
 
 </table>
 
 
-Comparison
+Run Time Comparison
 
 <table style="width: 1%">
   <tr>
@@ -483,28 +471,26 @@ Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Pg Query Builder</td>
-    <td style="white-space: nowrap;text-align: right">186.48 K</td>
+    <td style="white-space: nowrap">MyXQL Query Builder</td>
+    <td style="white-space: nowrap;text-align: right">742.88 K</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">MyXQL Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">182.02 K</td>
+    <td style="white-space: nowrap">Pg Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">729.59 K</td>
     <td style="white-space: nowrap; text-align: right">1.02x</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">SQLite3 Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">172.19 K</td>
-    <td style="white-space: nowrap; text-align: right">1.08x</td>
+    <td style="white-space: nowrap; text-align: right">721.11 K</td>
+    <td style="white-space: nowrap; text-align: right">1.03x</td>
   </tr>
 
 </table>
 
 
-
-<hr/>
 
 
 __Input: Ordinary Select All__
@@ -522,36 +508,36 @@ Run Time
   </tr>
 
   <tr>
+    <td style="white-space: nowrap">MyXQL Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">838.25 K</td>
+    <td style="white-space: nowrap; text-align: right">1.19 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1122.54%</td>
+    <td style="white-space: nowrap; text-align: right">1.04 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">1.46 &micro;s</td>
+  </tr>
+
+  <tr>
     <td style="white-space: nowrap">Pg Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">200.19 K</td>
-    <td style="white-space: nowrap; text-align: right">5.00 μs</td>
-    <td style="white-space: nowrap; text-align: right">±657.77%</td>
-    <td style="white-space: nowrap; text-align: right">3.49 μs</td>
-    <td style="white-space: nowrap; text-align: right">14.88 μs</td>
+    <td style="white-space: nowrap; text-align: right">822.53 K</td>
+    <td style="white-space: nowrap; text-align: right">1.22 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1179.00%</td>
+    <td style="white-space: nowrap; text-align: right">1.08 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">1.38 &micro;s</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">SQLite3 Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">199.77 K</td>
-    <td style="white-space: nowrap; text-align: right">5.01 μs</td>
-    <td style="white-space: nowrap; text-align: right">±698.35%</td>
-    <td style="white-space: nowrap; text-align: right">3.49 μs</td>
-    <td style="white-space: nowrap; text-align: right">13.90 μs</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">MyXQL Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">191.70 K</td>
-    <td style="white-space: nowrap; text-align: right">5.22 μs</td>
-    <td style="white-space: nowrap; text-align: right">±601.95%</td>
-    <td style="white-space: nowrap; text-align: right">3.56 μs</td>
-    <td style="white-space: nowrap; text-align: right">16.06 μs</td>
+    <td style="white-space: nowrap; text-align: right">809.74 K</td>
+    <td style="white-space: nowrap; text-align: right">1.23 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1198.22%</td>
+    <td style="white-space: nowrap; text-align: right">1.08 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">1.42 &micro;s</td>
   </tr>
 
 </table>
 
 
-Comparison
+Run Time Comparison
 
 <table style="width: 1%">
   <tr>
@@ -559,28 +545,26 @@ Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">Pg Query Builder</td>
-    <td style="white-space: nowrap;text-align: right">200.19 K</td>
+    <td style="white-space: nowrap">MyXQL Query Builder</td>
+    <td style="white-space: nowrap;text-align: right">838.25 K</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">SQLite3 Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">199.77 K</td>
-    <td style="white-space: nowrap; text-align: right">1.0x</td>
+    <td style="white-space: nowrap">Pg Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">822.53 K</td>
+    <td style="white-space: nowrap; text-align: right">1.02x</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">MyXQL Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">191.70 K</td>
+    <td style="white-space: nowrap">SQLite3 Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">809.74 K</td>
     <td style="white-space: nowrap; text-align: right">1.04x</td>
   </tr>
 
 </table>
 
 
-
-<hr/>
 
 
 __Input: Ordinary Update All__
@@ -598,36 +582,36 @@ Run Time
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">SQLite3 Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">263.35 K</td>
-    <td style="white-space: nowrap; text-align: right">3.80 μs</td>
-    <td style="white-space: nowrap; text-align: right">±1304.70%</td>
-    <td style="white-space: nowrap; text-align: right">2.86 μs</td>
-    <td style="white-space: nowrap; text-align: right">10.13 μs</td>
-  </tr>
-
-  <tr>
     <td style="white-space: nowrap">MyXQL Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">260.96 K</td>
-    <td style="white-space: nowrap; text-align: right">3.83 μs</td>
-    <td style="white-space: nowrap; text-align: right">±760.59%</td>
-    <td style="white-space: nowrap; text-align: right">2.86 μs</td>
-    <td style="white-space: nowrap; text-align: right">10.20 μs</td>
+    <td style="white-space: nowrap; text-align: right">1.03 M</td>
+    <td style="white-space: nowrap; text-align: right">971.15 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1801.37%</td>
+    <td style="white-space: nowrap; text-align: right">834 ns</td>
+    <td style="white-space: nowrap; text-align: right">1167 ns</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Pg Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">249.05 K</td>
-    <td style="white-space: nowrap; text-align: right">4.02 μs</td>
-    <td style="white-space: nowrap; text-align: right">±827.04%</td>
-    <td style="white-space: nowrap; text-align: right">2.86 μs</td>
-    <td style="white-space: nowrap; text-align: right">12.99 μs</td>
+    <td style="white-space: nowrap; text-align: right">1.01 M</td>
+    <td style="white-space: nowrap; text-align: right">990.87 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1533.42%</td>
+    <td style="white-space: nowrap; text-align: right">875 ns</td>
+    <td style="white-space: nowrap; text-align: right">1125 ns</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">SQLite3 Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">1.00 M</td>
+    <td style="white-space: nowrap; text-align: right">999.05 ns</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;1416.75%</td>
+    <td style="white-space: nowrap; text-align: right">875 ns</td>
+    <td style="white-space: nowrap; text-align: right">1166 ns</td>
   </tr>
 
 </table>
 
 
-Comparison
+Run Time Comparison
 
 <table style="width: 1%">
   <tr>
@@ -635,28 +619,26 @@ Comparison
     <th style="text-align: right">IPS</th>
     <th style="text-align: right">Slower</th>
   <tr>
-    <td style="white-space: nowrap">SQLite3 Query Builder</td>
-    <td style="white-space: nowrap;text-align: right">263.35 K</td>
+    <td style="white-space: nowrap">MyXQL Query Builder</td>
+    <td style="white-space: nowrap;text-align: right">1.03 M</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">MyXQL Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">260.96 K</td>
-    <td style="white-space: nowrap; text-align: right">1.01x</td>
+    <td style="white-space: nowrap">Pg Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">1.01 M</td>
+    <td style="white-space: nowrap; text-align: right">1.02x</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Pg Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">249.05 K</td>
-    <td style="white-space: nowrap; text-align: right">1.06x</td>
+    <td style="white-space: nowrap">SQLite3 Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">1.00 M</td>
+    <td style="white-space: nowrap; text-align: right">1.03x</td>
   </tr>
 
 </table>
 
 
-
-<hr/>
 
 
 __Input: Ordinary Where__
@@ -675,35 +657,35 @@ Run Time
 
   <tr>
     <td style="white-space: nowrap">MyXQL Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">162.26 K</td>
-    <td style="white-space: nowrap; text-align: right">6.16 μs</td>
-    <td style="white-space: nowrap; text-align: right">±343.86%</td>
-    <td style="white-space: nowrap; text-align: right">5.31 μs</td>
-    <td style="white-space: nowrap; text-align: right">17.74 μs</td>
-  </tr>
-
-  <tr>
-    <td style="white-space: nowrap">SQLite3 Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">159.31 K</td>
-    <td style="white-space: nowrap; text-align: right">6.28 μs</td>
-    <td style="white-space: nowrap; text-align: right">±305.50%</td>
-    <td style="white-space: nowrap; text-align: right">5.38 μs</td>
-    <td style="white-space: nowrap; text-align: right">19.35 μs</td>
+    <td style="white-space: nowrap; text-align: right">579.57 K</td>
+    <td style="white-space: nowrap; text-align: right">1.73 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;668.48%</td>
+    <td style="white-space: nowrap; text-align: right">1.54 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">2.17 &micro;s</td>
   </tr>
 
   <tr>
     <td style="white-space: nowrap">Pg Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">154.28 K</td>
-    <td style="white-space: nowrap; text-align: right">6.48 μs</td>
-    <td style="white-space: nowrap; text-align: right">±355.38%</td>
-    <td style="white-space: nowrap; text-align: right">5.45 μs</td>
-    <td style="white-space: nowrap; text-align: right">20.04 μs</td>
+    <td style="white-space: nowrap; text-align: right">574.41 K</td>
+    <td style="white-space: nowrap; text-align: right">1.74 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;631.02%</td>
+    <td style="white-space: nowrap; text-align: right">1.58 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">2.13 &micro;s</td>
+  </tr>
+
+  <tr>
+    <td style="white-space: nowrap">SQLite3 Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">568.60 K</td>
+    <td style="white-space: nowrap; text-align: right">1.76 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">&plusmn;635.93%</td>
+    <td style="white-space: nowrap; text-align: right">1.62 &micro;s</td>
+    <td style="white-space: nowrap; text-align: right">2.13 &micro;s</td>
   </tr>
 
 </table>
 
 
-Comparison
+Run Time Comparison
 
 <table style="width: 1%">
   <tr>
@@ -712,25 +694,20 @@ Comparison
     <th style="text-align: right">Slower</th>
   <tr>
     <td style="white-space: nowrap">MyXQL Query Builder</td>
-    <td style="white-space: nowrap;text-align: right">162.26 K</td>
+    <td style="white-space: nowrap;text-align: right">579.57 K</td>
     <td>&nbsp;</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">SQLite3 Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">159.31 K</td>
-    <td style="white-space: nowrap; text-align: right">1.02x</td>
+    <td style="white-space: nowrap">Pg Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">574.41 K</td>
+    <td style="white-space: nowrap; text-align: right">1.01x</td>
   </tr>
 
   <tr>
-    <td style="white-space: nowrap">Pg Query Builder</td>
-    <td style="white-space: nowrap; text-align: right">154.28 K</td>
-    <td style="white-space: nowrap; text-align: right">1.05x</td>
+    <td style="white-space: nowrap">SQLite3 Query Builder</td>
+    <td style="white-space: nowrap; text-align: right">568.60 K</td>
+    <td style="white-space: nowrap; text-align: right">1.02x</td>
   </tr>
 
 </table>
-
-
-
-<hr/>
-

--- a/lib/ecto/adapters/sqlite3/codec.ex
+++ b/lib/ecto/adapters/sqlite3/codec.ex
@@ -79,6 +79,10 @@ defmodule Ecto.Adapters.SQLite3.Codec do
 
   def time_decode(nil), do: {:ok, nil}
 
+  def time_decode(%Time{} = value) do
+    {:ok, value}
+  end
+
   def time_decode(value) do
     case Time.from_iso8601(value) do
       {:ok, _time} = result -> result

--- a/test/ecto/adapters/sqlite3/codec_test.exs
+++ b/test/ecto/adapters/sqlite3/codec_test.exs
@@ -116,6 +116,11 @@ defmodule Ecto.Adapters.SQLite3.CodecTest do
       {:ok, time} = Time.from_iso8601("23:50:07.123Z")
       assert {:ok, ^time} = Codec.time_decode("23:50:07.123Z")
     end
+
+    test "struct" do
+      time = ~T[10:28:14.748721]
+      assert {:ok, ^time} = Codec.time_decode(time)
+    end
   end
 
   describe ".utc_datetime_decode/1" do


### PR DESCRIPTION
This refreshes insertion benchmark stats + does a couple of minor fixes to the bench README.md.

I couldn't update all benchmarks due to a failure that I haven't had time to look into. Here's a full failure output:

<details>

```
Operating System: macOS
CPU Information: Apple M3 Max
Number of Available Cores: 16
Available memory: 128 GB
Elixir 1.16.2
Erlang 26.2.4
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 0 ns
reduction time: 0 ns
parallel: 1
inputs: Big 1 Million, Date attr, Medium 100 Thousand, Small 1 Thousand, Time attr, UUID attr
Estimated total run time: 2 min 6 s

Benchmarking MyXQL Loader with input Big 1 Million ...
Benchmarking MyXQL Loader with input Date attr ...
Benchmarking MyXQL Loader with input Medium 100 Thousand ...
Benchmarking MyXQL Loader with input Small 1 Thousand ...
Benchmarking MyXQL Loader with input Time attr ...
Benchmarking MyXQL Loader with input UUID attr ...
Benchmarking Pg Loader with input Big 1 Million ...
Benchmarking Pg Loader with input Date attr ...
Benchmarking Pg Loader with input Medium 100 Thousand ...
Benchmarking Pg Loader with input Small 1 Thousand ...
Benchmarking Pg Loader with input Time attr ...
Benchmarking Pg Loader with input UUID attr ...
Benchmarking SQLite3 Loader with input Big 1 Million ...
Benchmarking SQLite3 Loader with input Date attr ...
Benchmarking SQLite3 Loader with input Medium 100 Thousand ...
Benchmarking SQLite3 Loader with input Small 1 Thousand ...
Benchmarking SQLite3 Loader with input Time attr ...

09:27:11.506 [error] Task #PID<0.352.0> started from #PID<0.98.0> terminating
** (FunctionClauseError) no function clause matching in Calendar.ISO.parse_time/1
    (elixir 1.16.2) lib/calendar/iso.ex:297: Calendar.ISO.parse_time(~T[21:25:04.361140])
    (elixir 1.16.2) lib/calendar/time.ex:255: Time.from_iso8601/2
    (ecto_sqlite3 0.15.1) lib/ecto/adapters/sqlite3/codec.ex:83: Ecto.Adapters.SQLite3.Codec.time_decode/1
    (ecto 3.11.1) lib/ecto/type.ex:932: Ecto.Type.process_loaders/3
    (ecto 3.11.1) lib/ecto/schema/loader.ex:71: anonymous fn/5 in Ecto.Schema.Loader.unsafe_load/4
    (elixir 1.16.2) lib/enum.ex:2528: Enum."-reduce/3-lists^foldl/2-0-"/3
    (elixir 1.16.2) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
    (benchee 1.3.0) lib/benchee/benchmark/collect/time.ex:17: Benchee.Benchmark.Collect.Time.collect/1
Function: #Function<2.121299024/0 in Benchee.Utility.Parallel.map/2>
    Args: []
** (EXIT from #PID<0.98.0>) an exception was raised:
    ** (FunctionClauseError) no function clause matching in Calendar.ISO.parse_time/1
        (elixir 1.16.2) lib/calendar/iso.ex:297: Calendar.ISO.parse_time(~T[21:25:04.361140])
        (elixir 1.16.2) lib/calendar/time.ex:255: Time.from_iso8601/2
        (ecto_sqlite3 0.15.1) lib/ecto/adapters/sqlite3/codec.ex:83: Ecto.Adapters.SQLite3.Codec.time_decode/1
        (ecto 3.11.1) lib/ecto/type.ex:932: Ecto.Type.process_loaders/3
        (ecto 3.11.1) lib/ecto/schema/loader.ex:71: anonymous fn/5 in Ecto.Schema.Loader.unsafe_load/4
        (elixir 1.16.2) lib/enum.ex:2528: Enum."-reduce/3-lists^foldl/2-0-"/3
        (elixir 1.16.2) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
        (benchee 1.3.0) lib/benchee/benchmark/collect/time.ex:17: Benchee.Benchmark.Collect.Time.collect/1
```
</details>