### PR TITLE
Set minimum ecto version to 3.12

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,8 +35,8 @@ defmodule EctoSQLite3.MixProject do
   defp deps do
     [
       {:decimal, "~> 1.6 or ~> 2.0"},
-      {:ecto_sql, "~> 3.11"},
-      {:ecto, "~> 3.11"},
+      {:ecto_sql, "~> 3.12"},
+      {:ecto, "~> 3.12"},
       {:exqlite, "~> 0.22"},
       {:ex_doc, "~> 0.27", only: [:dev], runtime: false},
       {:jason, ">= 0.0.0", only: [:dev, :test, :docs]},


### PR DESCRIPTION
Thank you for working on ecto_sqlite3!

The latest release starts using `Ecto.Query.ByExpr` which [only became available in Ecto 3.12.0](https://hexdocs.pm/ecto/changelog.html#adapter-changes), so this simple PR updates the relevant dependency versions. Without this change, on Ecto 3.11, users will get run into an error like this:

```
==> ecto_sqlite3
Compiling 4 files (.ex)
     error: Ecto.Query.ByExpr.__struct__/0 is undefined, cannot expand struct Ecto.Query.ByExpr. Make sure the struct name is correct. If the struct name exists and is correct but it still cannot be found, you likely have cyclic module usage in your code
     │
 842 │   defp distinct(%ByExpr{expr: true}, _sources, _query), do: "DISTINCT "
     │                 ^
     │
     └─ lib/ecto/adapters/sqlite3/connection.ex:842:17: Ecto.Adapters.SQLite3.Connection.distinct/3


== Compilation error in file lib/ecto/adapters/sqlite3/connection.ex ==
** (CompileError) lib/ecto/adapters/sqlite3/connection.ex: cannot compile module Ecto.Adapters.SQLite3.Connection (errors have been logged)
    lib/ecto/adapters/sqlite3/connection.ex:842: (module)
```

You probably didn't come across this because ex_doc depends on earmark_parser that pulls in ecto 3.12. 