### PR TITLE
Add documentation about transaction modes

### DIFF
--- a/lib/ecto/adapters/sqlite3.ex
+++ b/lib/ecto/adapters/sqlite3.ex
@@ -188,18 +188,36 @@ defmodule Ecto.Adapters.SQLite3 do
 
   Here are several ways to specify a different transaction mode:
 
-  1. **Pass `mode: :immediate` to `Repo.transaction/2`:** Use this approach to set the transaction mode for individual transactions.
+  **Pass `mode: :immediate` to `Repo.transaction/2`:** Use this approach to set 
+  the transaction mode for individual transactions.
 
-  2. **Define custom transaction functions:** Create wrappers, such as `Repo.immediate_transaction/2` or `Repo.deferred_transaction/2`,
-    to easily apply different modes where needed.
+      Multi.new()
+      |> Multi.run(:example, fn _repo, _changes_so_far ->
+        # ... do some work ...
+      end)
+      |> Repo.transaction(mode: :immediate)
 
-  3. **Set a global default:** Configure `:default_transaction_mode` to apply a preferred mode for all transactions.
+  **Define custom transaction functions:** Create wrappers, such as 
+  `Repo.immediate_transaction/2` or `Repo.deferred_transaction/2`, to easily 
+  apply different modes where needed.
 
-  ```elixir
-  config :my_app, MyApp.Repo,
-    database: "path/to/my/database.db",
-    default_transaction_mode: :immediate
-  ```
+      defmodule MyApp.Repo do
+        def immediate_transaction(fun_or_multi) do
+          transaction(fun_or_multi, mode: :immediate)
+        end
+
+        def deferred_transaction(fun_or_multi) do
+          transaction(fun_or_multi, mode: :deferred)
+        end
+      end
+
+  **Set a global default:** Configure `:default_transaction_mode` to apply a 
+  preferred mode for all transactions, unless explicitly passed a different
+  `:mode` to `Repo.transaction/2`.
+
+      config :my_app, MyApp.Repo,
+        database: "path/to/my/database.db",
+        default_transaction_mode: :immediate
 
   [3]: https://www.sqlite.org/compile.html
   [4]: https://www.sqlite.org/whentouse.html

--- a/lib/ecto/adapters/sqlite3.ex
+++ b/lib/ecto/adapters/sqlite3.ex
@@ -182,8 +182,9 @@ defmodule Ecto.Adapters.SQLite3 do
 
   ### Transaction mode
 
-  By default, [SQLite transactions][8] run in `DEFERRED` mode. However, in typical web applications with a balanced load
-  of reads and writes, using `IMMEDIATE` mode can yield better performance.
+  By default, [SQLite transactions][8] run in `DEFERRED` mode. However, in 
+  web applications with a balanced load of reads and writes, using  `IMMEDIATE` 
+  mode may yield better performance.
 
   Here are several ways to specify a different transaction mode:
 

--- a/lib/ecto/adapters/sqlite3.ex
+++ b/lib/ecto/adapters/sqlite3.ex
@@ -201,8 +201,6 @@ defmodule Ecto.Adapters.SQLite3 do
     default_transaction_mode: :immediate
   ```
 
-  See [this GitHub issue](https://github.com/elixir-sqlite/ecto_sqlite3/issues/153) for more details.
-
   [3]: https://www.sqlite.org/compile.html
   [4]: https://www.sqlite.org/whentouse.html
   [5]: https://www.sqlite.org/datatype3.html


### PR DESCRIPTION
Added docs how to use different transaction modes:

1. **Pass `mode: :immediate` to `Repo.transaction/2`:** Use this approach to set the transaction mode for individual transactions.
2. **Define custom transaction functions:** Create wrappers, such as `Repo.immediate_transaction/2` or `Repo.deferred_transaction/2`, to easily apply different modes where needed.
3. **Set a global default:** Configure `:default_transaction_mode` to apply a preferred mode for all transactions.