### PR TITLE
Report correct error for value lists in joins

### DIFF
--- a/lib/ecto/adapters/sqlite3/connection.ex
+++ b/lib/ecto/adapters/sqlite3/connection.ex
@@ -1909,9 +1909,11 @@ defmodule Ecto.Adapters.SQLite3.Connection do
 
   defp quote_table(nil, name), do: quote_entity(name)
 
-  defp quote_table(_prefix, _name) do
+  defp quote_table(prefix, _name) when is_atom(prefix) or is_binary(prefix) do
     raise ArgumentError, "SQLite3 does not support table prefixes"
   end
+
+  defp quote_table(_, name), do: quote_entity(name)
 
   defp quote_entity(val) when is_atom(val) do
     quote_entity(Atom.to_string(val))

--- a/lib/ecto/adapters/sqlite3/connection.ex
+++ b/lib/ecto/adapters/sqlite3/connection.ex
@@ -993,7 +993,8 @@ defmodule Ecto.Adapters.SQLite3.Connection do
   defp using_join(%{joins: joins} = query, _kind, prefix, sources) do
     froms =
       Enum.map_intersperse(joins, ", ", fn
-        %JoinExpr{qual: _qual, ix: ix, source: source} ->
+        %JoinExpr{qual: _qual, ix: ix, source: source} = join ->
+          assert_valid_join(join, query)
           {join, name} = get_source(query, sources, ix, source)
           [join, " AS " | name]
       end)

--- a/test/ecto/adapters/sqlite3/connection/join_test.exs
+++ b/test/ecto/adapters/sqlite3/connection/join_test.exs
@@ -135,6 +135,24 @@ defmodule Ecto.Adapters.SQLite3.Connection.JoinTest do
     end
   end
 
+  test "join with values is not supported" do
+    assert_raise Ecto.QueryError, fn ->
+      rows = [%{x: 1, y: 1}, %{x: 2, y: 2}]
+      types = %{x: :integer, y: :integer}
+
+      Schema
+      |> join(
+        :inner,
+        [p],
+        q in values(rows, types),
+        on: [x: p.x(), y: p.y()]
+      )
+      |> select([p, q], {p.id, q.x})
+      |> plan()
+      |> all()
+    end
+  end
+
   test "join with fragment" do
     query =
       Schema


### PR DESCRIPTION
See https://github.com/elixir-sqlite/ecto_sqlite3/issues/138

The wrong error was being thrown due to the third param in the source passed into `create_name` is only a binary when its a prefix, while other SQL syntax passes in other terms as the third parameter.

`JOIN VALUES((...),(...)) AS` clauses pass in a `{values, index, number_of_values}` tuple as the third parameter, for instance.

So this fix is in two parts: one fixes `quote_table` to account for this, the other introduces an `assert_valid_join` that validates joins, generating consistent, clear errors as needed.

Note: I did actually attempt to implement `VALUES()` joins .. however, while SQLITE does support the `VALUES()` syntax, it does not work meaningfully in joins, as it does not support column aliases on tables, meaning there is no way to *name* the columns in the values list (as Ecto provides for), and as such no way to use a values list as a join table. I did get the actual `VALUES` list to be accepted by sqlite's query parser, though ... but that turned out to be for not due to these other limitations in the engine. Ah well ...