### PR TITLE
blob encode uuids if stored as binary

### DIFF
--- a/lib/ecto/adapters/sqlite3.ex
+++ b/lib/ecto/adapters/sqlite3.ex
@@ -479,7 +479,7 @@ defmodule Ecto.Adapters.SQLite3 do
   def dumpers(:uuid, type) do
     case Application.get_env(:ecto_sqlite3, :uuid_type, :string) do
       :string -> []
-      :binary -> [type]
+      :binary -> [type, &Codec.blob_encode/1]
     end
   end
 


### PR DESCRIPTION
Marking as a draft because I actually don't know if this is the correct solution

I'm using https://github.com/sloanelybutsurely/typeid-elixir which implements an `Ecto.ParameterizedType` that can be either a `:string` or `:uuid` type. As strings they look like "user_01jz8mgbxkevwagbhr8cdqhpqh"

I want to use `ecto_sqlite3` with `uuid_type: :binary` for efficiency reasons

Storing the TypeID as `:uuid` will drop the prefix, leaving only the suffix "01jz8mgbxkevwagbhr8cdqhpqh", then convert that suffix from base32  to binary uuidv7 — but Ecto blows up in `STRICT` tables with `BLOB` columns because `typeid_elixir` is unaware `exqlite` needs to receive `{:blob, value}`, not only `value` (binary uuidv7).

```
** (Exqlite.Error) cannot store TEXT value in BLOB column users.id
```

I've added blob encoding to the dumper pipeline, but again, maybe this is not the correct solution.