### PR TITLE
Use :prefix to query attached databases

### DIFF
--- a/integration_test/test_helper.exs
+++ b/integration_test/test_helper.exs
@@ -91,7 +91,6 @@ excludes = [
   :lock_for_migrations,
 
   # Migration we don't support
-  :prefix,
   :add_column_if_not_exists,
   :remove_column_if_exists,
   :alter_primary_key,

--- a/lib/ecto/adapters/sqlite3/connection.ex
+++ b/lib/ecto/adapters/sqlite3/connection.ex
@@ -1945,8 +1945,8 @@ defmodule Ecto.Adapters.SQLite3.Connection do
 
   defp quote_table(nil, name), do: quote_entity(name)
 
-  defp quote_table(prefix, _name) when is_atom(prefix) or is_binary(prefix) do
-    raise ArgumentError, "SQLite3 does not support table prefixes"
+  defp quote_table(prefix, name) when is_atom(prefix) or is_binary(prefix) do
+    "#{prefix}.#{name}"
   end
 
   defp quote_table(_, name), do: quote_entity(name)

--- a/lib/ecto/adapters/sqlite3/connection.ex
+++ b/lib/ecto/adapters/sqlite3/connection.ex
@@ -1826,7 +1826,7 @@ defmodule Ecto.Adapters.SQLite3.Connection do
       " CONSTRAINT ",
       reference_name(ref, table, name),
       " REFERENCES ",
-      quote_table(ref.prefix || table.prefix, ref.table),
+      quote_table(nil, ref.table),
       ?(,
       quote_name(ref.column),
       ?),

--- a/lib/ecto/adapters/sqlite3/connection.ex
+++ b/lib/ecto/adapters/sqlite3/connection.ex
@@ -1946,7 +1946,7 @@ defmodule Ecto.Adapters.SQLite3.Connection do
   defp quote_table(nil, name), do: quote_entity(name)
 
   defp quote_table(prefix, name) when is_atom(prefix) or is_binary(prefix) do
-    "#{prefix}.#{name}"
+    [prefix, ?., name]
   end
 
   defp quote_table(_, name), do: quote_entity(name)

--- a/test/ecto/adapters/sqlite3/connection/delete_all_test.exs
+++ b/test/ecto/adapters/sqlite3/connection/delete_all_test.exs
@@ -65,20 +65,20 @@ defmodule Ecto.Adapters.SQLite3.Connection.DeleteAllTest do
   end
 
   test "delete all with prefix" do
-    assert_raise ArgumentError, "SQLite3 does not support table prefixes", fn ->
+    query =
       Schema
       |> Ecto.Queryable.to_query()
       |> Map.put(:prefix, "prefix")
       |> plan()
-      |> delete_all()
-    end
 
-    assert_raise ArgumentError, "SQLite3 does not support table prefixes", fn ->
+    assert ~s{DELETE FROM prefix.schema AS s0} == delete_all(query)
+
+    query =
       Schema
       |> from(prefix: "first")
       |> Map.put(:prefix, "prefix")
       |> plan()
-      |> delete_all()
-    end
+
+    assert ~s{DELETE FROM first.schema AS s0} == delete_all(query)
   end
 end

--- a/test/ecto/adapters/sqlite3/connection/insert_test.exs
+++ b/test/ecto/adapters/sqlite3/connection/insert_test.exs
@@ -25,9 +25,8 @@ defmodule Ecto.Adapters.SQLite3.Connection.InsertTest do
     query = insert(nil, "schema", [], [[]], {:raise, [], []}, [])
     assert query == ~s{INSERT INTO "schema" DEFAULT VALUES}
 
-    assert_raise ArgumentError, "SQLite3 does not support table prefixes", fn ->
-      insert("prefix", "schema", [], [[]], {:raise, [], []}, [])
-    end
+    query = insert("prefix", "schema", [], [[]], {:raise, [], []}, [])
+    assert query == ~s{INSERT INTO prefix.schema DEFAULT VALUES}
 
     query = insert(nil, "schema", [:x, :y], [[:x, :y]], {:raise, [], []}, [:id])
     assert query == ~s{INSERT INTO "schema" ("x","y") VALUES (?1,?2) RETURNING "id"}

--- a/test/ecto/adapters/sqlite3/connection/join_test.exs
+++ b/test/ecto/adapters/sqlite3/connection/join_test.exs
@@ -114,25 +114,27 @@ defmodule Ecto.Adapters.SQLite3.Connection.JoinTest do
              ~s{) AS s1 ON 1} == all(query)
   end
 
-  test "join with prefix is not supported" do
-    assert_raise ArgumentError, "SQLite3 does not support table prefixes", fn ->
+  test "join with prefix" do
+    query =
       Schema
       |> join(:inner, [p], q in Schema2, on: p.x == q.z)
       |> select([], true)
       |> Map.put(:prefix, "prefix")
       |> plan()
-      |> all()
-    end
 
-    assert_raise ArgumentError, "SQLite3 does not support table prefixes", fn ->
+    assert ~s{SELECT 1 FROM prefix.schema AS s0 INNER JOIN prefix.schema2 AS s1 ON s0."x" = s1."z"} ==
+             all(query)
+
+    query =
       Schema
       |> from(prefix: "first")
       |> join(:inner, [p], q in Schema2, on: p.x == q.z, prefix: "second")
       |> select([], true)
       |> Map.put(:prefix, "prefix")
       |> plan()
-      |> all()
-    end
+
+    assert ~s{SELECT 1 FROM first.schema AS s0 INNER JOIN second.schema2 AS s1 ON s0."x" = s1."z"} ==
+             all(query)
   end
 
   test "join with values" do

--- a/test/ecto/adapters/sqlite3/connection/update_all_test.exs
+++ b/test/ecto/adapters/sqlite3/connection/update_all_test.exs
@@ -123,12 +123,12 @@ defmodule Ecto.Adapters.SQLite3.Connection.UpdateAllTest do
   end
 
   test "update all with prefix" do
-    assert_raise ArgumentError, "SQLite3 does not support table prefixes", fn ->
+    query =
       from(m in Schema, update: [set: [x: 0]])
       |> Map.put(:prefix, "prefix")
       |> plan(:update_all)
-      |> update_all()
-    end
+
+    assert ~s{UPDATE prefix.schema AS s0 SET "x" = 0} == update_all(query)
   end
 
   test "update all with left join" do


### PR DESCRIPTION
SQLite allows attached databases, and their tables can be referenced by prefixing the schema name

```sql
ATTACH DATABASE "/tmp/database.db" AS another;
SELECT * FROM another.things; 
```

I think it makes sense to use ecto's `:prefix` option to query these schemas.

I'm currently using this patch like...

```elixir
as = "another"

Repo.checkout(fn ->
    Repo.query("ATTACH DATABASE ? AS ?", ["/tmp/database.db", as])

    Repo.transact(fn ->
        {:ok, service} = Repo.insert(%Service{id: 1})
        Repo.insert(%Registry{id: 1, service_id: service.id}, prefix: as)
    end)

    Repo.query("DETACH DATABASE ?", [as])
end)
```

Where I'm wrapping a transaction with ATTACH/DETACH to insert rows with transactional guarantees across both databases