### PR TITLE
Fix compile warnings and update CI matrix for latest Elixir/OTP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        elixir: ["1.19"]
-        otp: ["28"]
+        elixir: ["1.20"]
+        otp: ["29"]
     steps:
       - uses: actions/checkout@v6
       - uses: erlef/setup-beam@v1
@@ -41,11 +41,15 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        elixir: ["1.19", "1.18", "1.17"]
-        otp: ["28", "27", "26"]
+        elixir: ["1.20", "1.19", "1.18"]
+        otp: ["29", "28", "27"]
         exclude:
-          - elixir: "1.17"
+          - elixir: "1.18"
             otp: "28"
+          - elixir: "1.18"
+            otp: "29"
+          - elixir: "1.19"
+            otp: "29"
     steps:
       - uses: actions/checkout@v6
       - uses: erlef/setup-beam@v1

--- a/lib/ecto/adapters/sqlite3/connection.ex
+++ b/lib/ecto/adapters/sqlite3/connection.ex
@@ -551,11 +551,6 @@ defmodule Ecto.Adapters.SQLite3.Connection do
   end
 
   @impl true
-  def execute_ddl({:drop_if_exists, %Index{concurrently: true}}) do
-    raise ArgumentError, "`concurrently` is not supported with SQLite3"
-  end
-
-  @impl true
   def execute_ddl({:drop_if_exists, %Index{} = index}) do
     [
       [
@@ -604,75 +599,8 @@ defmodule Ecto.Adapters.SQLite3.Connection do
     raise ArgumentError, "SQLite3 adapter does not support keyword lists in execute"
   end
 
-  @impl true
-  def execute_ddl({:create, %Index{} = index}) do
-    fields = Enum.map_intersperse(index.columns, ", ", &index_expr/1)
-
-    [
-      [
-        "CREATE ",
-        if_do(index.unique, "UNIQUE "),
-        "INDEX",
-        ?\s,
-        quote_name(index.name),
-        " ON ",
-        quote_table(index.prefix, index.table),
-        " (",
-        fields,
-        ?),
-        if_do(index.where, [" WHERE ", to_string(index.where)])
-      ]
-    ]
-  end
-
-  def execute_ddl({:create_if_not_exists, %Index{} = index}) do
-    fields = Enum.map_intersperse(index.columns, ", ", &index_expr/1)
-
-    [
-      [
-        "CREATE ",
-        if_do(index.unique, "UNIQUE "),
-        "INDEX IF NOT EXISTS",
-        ?\s,
-        quote_name(index.name),
-        " ON ",
-        quote_table(index.prefix, index.table),
-        " (",
-        fields,
-        ?),
-        if_do(index.where, [" WHERE ", to_string(index.where)])
-      ]
-    ]
-  end
-
   def execute_ddl({:create, %Constraint{}}) do
     raise ArgumentError, "SQLite3 does not support ALTER TABLE ADD CONSTRAINT."
-  end
-
-  def execute_ddl({:drop, %Index{} = index}) do
-    [
-      [
-        "DROP INDEX ",
-        quote_table(index.prefix, index.name)
-      ]
-    ]
-  end
-
-  def execute_ddl({:drop, %Index{} = index, _mode}) do
-    execute_ddl({:drop, index})
-  end
-
-  def execute_ddl({:drop_if_exists, %Index{} = index}) do
-    [
-      [
-        "DROP INDEX IF EXISTS ",
-        quote_table(index.prefix, index.name)
-      ]
-    ]
-  end
-
-  def execute_ddl({:drop_if_exists, %Index{} = index, _mode}) do
-    execute_ddl({:drop_if_exists, index})
   end
 
   def execute_ddl({:drop, %Constraint{}, _mode}) do
@@ -683,41 +611,11 @@ defmodule Ecto.Adapters.SQLite3.Connection do
     raise ArgumentError, "SQLite3 does not support ALTER TABLE DROP CONSTRAINT."
   end
 
-  def execute_ddl({:rename, %Table{} = current_table, %Table{} = new_table}) do
-    [
-      [
-        "ALTER TABLE ",
-        quote_table(current_table.prefix, current_table.name),
-        " RENAME TO ",
-        quote_table(new_table.prefix, new_table.name)
-      ]
-    ]
-  end
-
-  def execute_ddl({:rename, %Table{} = table, current_column, new_column}) do
-    [
-      [
-        "ALTER TABLE ",
-        quote_table(table.prefix, table.name),
-        " RENAME COLUMN ",
-        quote_name(current_column),
-        " TO ",
-        quote_name(new_column)
-      ]
-    ]
-  end
-
   def execute_ddl({:rename, %Index{} = index, new_index}) do
     [
       execute_ddl({:drop, index}),
       execute_ddl({:create, %Index{index | name: new_index}})
     ]
-  end
-
-  def execute_ddl(string) when is_binary(string), do: [string]
-
-  def execute_ddl(keyword) when is_list(keyword) do
-    raise ArgumentError, "SQLite3 adapter does not support keyword lists in execute"
   end
 
   @impl true


### PR DESCRIPTION
## Summary

Two unrelated maintenance changes bundled together:

### 1. Fix redundant `execute_ddl/1` clauses

`mix compile --warnings-as-errors` was failing with 11 "redundant clause" warnings, all in `lib/ecto/adapters/sqlite3/connection.ex`. The file had two duplicate sets of `execute_ddl/1` clauses: a newer set (with `@impl true` markers) and an older set of duplicates.

With the recent Ecto upgrade (commit `e408901`, "Upgrade ecto_sql and bump version"), the upstream type system became smarter and started flagging the duplicate clauses as redundant. Since CI uses `--warnings-as-errors`, the build was broken.

**Removed 11 duplicate clauses** (~100 lines), keeping the first (correct) set intact. Also removed one additional redundant `{:drop_if_exists, %Index{concurrently: true}}` clause that is fully covered by the wildcard `{:_, %Index{concurrently: true}}` clause (which raises the same `ArgumentError`).

The original non-duplicate clauses for `Constraint` operations and `Index` rename are preserved.

### 2. Update CI matrix to Elixir 1.18-1.20 / OTP 27-29

Per the official [Elixir/OTP compatibility table](https://elixir.hexdocs.pm/compatibility-and-deprecations.html) (June 2026):

| Elixir | Supported OTP |
| --- | --- |
| 1.20 | 27–29 (latest) |
| 1.19 | 26–28 |
| 1.18 | 25–27 |

| Change | Old | New |
| --- | --- | --- |
| Elixir | 1.17, 1.18, 1.19 | **1.18, 1.19, 1.20** |
| OTP | 26, 27, 28 | **27, 28, 29** |
| Lint job | 1.19 + OTP 28 | **1.20 + OTP 29** |
| Excludes | 1.17 + OTP 28 | 1.18 + OTP 28, 1.18 + OTP 29, 1.19 + OTP 29 |

Drops Elixir 1.17 and OTP 26 (both EOL), adds Elixir 1.20 and OTP 29 (latest). 6 valid combinations remain, all within the official support ranges.

## Verification

- `mix compile --warnings-as-errors` passes cleanly
- `mix test` passes (321 tests, 0 failures)
- YAML is valid; matrix verified to produce 6 active combinations